### PR TITLE
Fixes incorrectly rewritten and outdated links in the documentation

### DIFF
--- a/docs/book/v1/cookbook/common-prefix-for-routes.md
+++ b/docs/book/v1/cookbook/common-prefix-for-routes.md
@@ -41,5 +41,5 @@ $app->run();
 ```
 
 The above works, because every `Application` instance is itself middleware, and, more specifically,
-an instance of [Stratigility's `MiddlewarePipe`](https://github.com/laminas/laminas-stratigility/blob/master/doc/book/middleware.md),
+an instance of [Stratigility's `MiddlewarePipe`](https://docs.laminas.dev/laminas-stratigility/v1/middleware/),
 which provides the ability to compose middleware.

--- a/docs/book/v1/cookbook/debug-toolbars.md
+++ b/docs/book/v1/cookbook/debug-toolbars.md
@@ -7,7 +7,7 @@ As an Mezzio user, how can you get similar functionality?
 
 ## Zend Server Z-Ray
 
-[Zend Server](https://www.zend.com/en/products/laminas_server) ships with a tool
+[Zend Server](https://www.zend.com/products/zend-server) ships with a tool
 called [Z-Ray](https://www.zend.com/en/products/server/z-ray), which provides
 both a debug toolbar and debug console (for API debugging). Z-Ray is also
 currently [available as a standalone technology
@@ -18,7 +18,7 @@ When using Zend Server or the standalone Z-Ray, you do not need to make any
 changes to your application whatsoever to benefit from it; you simply need to
 make sure Z-Ray is enabled and/or that you've setup a security token to
 selectively enable it on-demand. See the
-[Z-Ray documentation](http://files.zend.com/help/Laminas-Server/content/z-ray_concept.htm)
+[Z-Ray documentation](http://files.zend.com/help/Zend-Server/content/z-ray_concept.htm)
 for full usage details.
 
 ## bitExpert/prophiler-psr7-middleware
@@ -36,7 +36,7 @@ $ composer require bitExpert/prophiler-psr7-middleware
 
 From there, you will need to create a factory for the middleware, and add it to
 your middleware pipeline. Stephan Hochdörfer, author of the package, has written
-a [post detailing these steps](https://blog.bitexpert.de/blog/using-prophiler-with-mezzio/).
+a [post detailing these steps](https://blog.bitexpert.de/blog/prophiler-psr-7-middleware/).
 
 > ### Use locally!
 >

--- a/docs/book/v1/cookbook/flash-messengers.md
+++ b/docs/book/v1/cookbook/flash-messengers.md
@@ -115,9 +115,9 @@ public function __invoke($request, $response, $next)
 
 From there, it's a matter of providing the flash messages to your template.
 
-## damess/mezzio-session-middleware and Aura.Session
+## damess/expressive-session-middleware and Aura.Session
 
-[damess/mezzio-session-middleware](https://github.com/dannym87/mezzio-session-middleware)
+[damess/mezzio-session-middleware](https://github.com/dannym87/expressive-session-middleware)
 provides middleware for initializing an
 [Aura.Session](https://github.com/auraphp/Aura.Session) instance; Aura.Session
 provides flash messaging capabilities as part of its featureset.

--- a/docs/book/v1/cookbook/modular-layout.md
+++ b/docs/book/v1/cookbook/modular-layout.md
@@ -10,7 +10,7 @@ doesn't affect performance, and offers extensive flexibility: each module can
 provide its own services (with factories), default configuration, and routes.
 
 This cookbook will show how to organize modules using
-[mtymek/mezzio-config-manager](https://github.com/mtymek/mezzio-config-manager),
+[mtymek/mezzio-config-manager](https://github.com/mtymek/expressive-config-manager),
 a lightweight library that aggregates and merges configuration, optionally caching it.
 
 ## Install the configuration manager
@@ -154,4 +154,4 @@ This approach may look simple, but it is flexible and powerful:
 - If cached config is found, `ConfigManager` does not iterate over provider list.
 
 For more details, please refer to the
-[Config Manager Documentation](https://github.com/mtymek/mezzio-config-manager#mezzio-configuration-manager).
+[Config Manager Documentation](https://github.com/mtymek/expressive-config-manager#expressive-configuration-manager).

--- a/docs/book/v1/cookbook/using-custom-view-helpers.md
+++ b/docs/book/v1/cookbook/using-custom-view-helpers.md
@@ -22,5 +22,5 @@ return [
 The last is the one you want. In this, you can define service mappings,
 including aliases, invokables, factories, and abstract factories to define how
 helpers are named and created.
-[See the laminas-view custom helpers documentation](https://docs.laminas.dev/laminas.view.helpers.advanced-usage.html#laminas-view-helpers-advanced-usage)
+[See the laminas-view custom helpers documentation](https://docs.laminas.dev/laminas-view/helpers/advanced-usage/)
 for information on how to populate this configuration.

--- a/docs/book/v1/features/application.md
+++ b/docs/book/v1/features/application.md
@@ -1,7 +1,7 @@
 # Applications
 
 In mezzio, you define a `Mezzio\Application` instance and
-execute it. The `Application` instance is itself [middleware](https://github.com/laminas/laminas-stratigility/blob/master/doc/book/middleware.md)
+execute it. The `Application` instance is itself [middleware](https://docs.laminas.dev/laminas-stratigility/v1/middleware/)
 that composes:
 
 - a [router](router/intro.md), for dynamically routing requests to middleware.
@@ -9,7 +9,7 @@ that composes:
   middleware to dispatch.
 - a [final handler](error-handling.md), for handling error conditions raised by
   the application.
-- an [emitter](https://github.com/laminas/laminas-diactoros/blob/master/doc/book/emitting-responses.md),
+- an [emitter](https://docs.laminas.dev/laminas-diactoros/v1/emitting-responses/),
   for emitting the response when application execution is complete.
 
 You can define the `Application` instance in several ways:
@@ -213,7 +213,7 @@ methods for retrieving them. They include:
 - `getContainer()`: returns the composed [container-interop](https://github.com/container-interop/container-interop)
   instance (used to retrieve routed middleware).
 - `getEmitter()`: returns the composed
-  [emitter](https://github.com/laminas/laminas-diactoros/blob/master/doc/book/emitting-responses.md),
+  [emitter](https://docs.laminas.dev/laminas-diactoros/v1/emitting-responses/),
   typically a `Mezzio\Emitter\EmitterStack` instance.
 - `getFinalHandler(ResponseInterface $response = null)`: retrieves the final
   handler instance. This is middleware with the signature `function ($request,

--- a/docs/book/v1/features/container/aura-di.md
+++ b/docs/book/v1/features/container/aura-di.md
@@ -23,7 +23,7 @@ $ composer require "aura/di:3.0.*@beta"
 ## Configuration
 
 Aura.Di can help you to organize your code better with
-[ContainerConfig classes](http://auraphp.com/packages/Aura.Di/config.html) and
+[ContainerConfig classes](http://auraphp.com/packages/3.x/Di/config.html) and
 [two step configuration](http://auraphp.com/blog/2014/04/07/two-stage-config/).
 In this example, we'll put that in `config/services.php`:
 

--- a/docs/book/v1/features/emitters.md
+++ b/docs/book/v1/features/emitters.md
@@ -4,7 +4,7 @@ To simplify the usage of Mezzio, we added the `run()` method, which handles
 the incoming request, and emits a response.
 
 The latter aspect, emitting the response, is the responsibility of an
-[emitter](https://github.com/laminas/laminas-diactoros/blob/master/doc/book/emitting-responses.md).
+[emitter](https://docs.laminas.dev/laminas-diactoros/v1/emitting-responses/).
 An emitter accepts a response instance, and then does something with it, usually
 sending the response back to a browser.
 

--- a/docs/book/v1/features/error-handling.md
+++ b/docs/book/v1/features/error-handling.md
@@ -1,7 +1,7 @@
 # Error Handling
 
 Mezzio provides error handling out of the box, via laminas-stratigility's [FinalHandler
-implementation](https://github.com/laminas/laminas-stratigility/blob/master/doc/book/api.md#finalhandler).
+implementation](https://docs.laminas.dev/laminas-stratigility/v1/api/#finalhandler).
 This pseudo-middleware is executed in the following conditions:
 
 - If the middleware stack is exhausted, and no middleware has returned a response.

--- a/docs/book/v1/features/router/intro.md
+++ b/docs/book/v1/features/router/intro.md
@@ -97,4 +97,4 @@ Mezzio currently ships with adapters for the following routers:
 
 - [Aura.Router](aura.md)
 - [FastRoute](fast-route.md)
-- [laminas-mvc Router](laminas.md)
+- [laminas-mvc Router](laminas-router.md)

--- a/docs/book/v1/getting-started/features.md
+++ b/docs/book/v1/getting-started/features.md
@@ -1,7 +1,7 @@
 # Overview
 
 Mezzio allows you to write [PSR-7](http://www.php-fig.org/psr/psr-7/)
-[middleware](https://github.com/laminas/laminas-stratigility/blob/master/doc/book/middleware.md)
+[middleware](https://docs.laminas.dev/laminas-stratigility/v1/middleware/)
 applications for the web.
 
 PSR-7 is a standard defining HTTP message interfaces; these are the incoming
@@ -69,7 +69,7 @@ features it provides include:
 
 Below is a diagram detailing the workflow used by Mezzio.
 
-![Mezzio Architectural Flow](../images/architecture.png)
+![Mezzio Architectural Flow](../../images/architecture.png)
 
 The `Application` acts as an "onion"; in the diagram above, the top is the
 outer-most layer of the onion, while the bottom is the inner-most.

--- a/docs/book/v1/reference/mezzio-projects.md
+++ b/docs/book/v1/reference/mezzio-projects.md
@@ -6,13 +6,12 @@ mezzio.
 
 ## Sample Code & Tutorials
 
-- Mezzio Tutorial (WIP) - [*source*](https://github.com/RalfEggert/mezzio-tutorial)
-- [AstroSplash](http://www.sitepoint.com/build-nasa-photo-gallery-mezzio/) - [*source*](https://github.com/AndrewCarterUK/AstroSplash)
+- Expressive Tutorial (WIP) - [*source*](https://github.com/RalfEggert/zend-expressive-tutorial)
+- [AstroSplash](http://www.sitepoint.com/build-nasa-photo-gallery-zend-expressive/) - [*source*](https://github.com/AndrewCarterUK/AstroSplash)
 - [php-ddd-cargo-sample](https://codeliner.github.io/php-ddd-cargo-sample/) - [*source*](https://github.com/codeliner/php-ddd-cargo-sample)
 
 ## Personal Sites
 
 - [mwop.net](https://mwop.net/) - [*source*](https://github.com/weierophinney/mwop.net)
-- [xtreamwayz.com](https://xtreamwayz.com/) - [*source*](https://github.com/xtreamwayz/xtreamwayz.com)
-- [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/website-mezzio)
+- [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/alejandrocelaya.com)
 - [zimuel.it](http://www.zimuel.it) - [*source*](https://github.com/ezimuel/zimuel.it)

--- a/docs/book/v1/reference/migration/to-v1-1.md
+++ b/docs/book/v1/reference/migration/to-v1-1.md
@@ -111,7 +111,7 @@ return [
 ];
 ```
 
-If you are [programmatically creating your pipeline](https://mwop.net/blog/2016-05-16-programmatic-mezzio.html),
+If you are [programmatically creating your pipeline](https://mwop.net/blog/2016-05-16-programmatic-expressive.html),
 use the following:
 
 ```php

--- a/docs/book/v1/why-mezzio.md
+++ b/docs/book/v1/why-mezzio.md
@@ -13,7 +13,7 @@ decisions need be made up front; developers know where new code goes, and how it
 will wire into the overall application.
 
 Additionally, a number of training courses exist, including [offerings by
-Laminas](https://www.zend.com/en/services/training/api-tools-fundamentals-i), allowing you
+Zend](https://www.zend.com/training/zf-fundamentals), allowing you
 or your team to fully learn the framework and take advantage of all its features.
 
 Finally, laminas-mvc has a lively [module ecosystem](https://packagist.org/search/?q=laminas),

--- a/docs/book/v2/cookbook/common-prefix-for-routes.md
+++ b/docs/book/v2/cookbook/common-prefix-for-routes.md
@@ -42,5 +42,5 @@ $app->run();
 ```
 
 The above works, because every `Application` instance is itself middleware, and, more specifically,
-an instance of [Stratigility's `MiddlewarePipe`](https://github.com/laminas/laminas-stratigility/blob/master/doc/book/middleware.md),
+an instance of [Stratigility's `MiddlewarePipe`](https://docs.laminas.dev/laminas-stratigility/v1/middleware/),
 which provides the ability to compose middleware.

--- a/docs/book/v2/cookbook/debug-toolbars.md
+++ b/docs/book/v2/cookbook/debug-toolbars.md
@@ -7,7 +7,7 @@ As an Mezzio user, how can you get similar functionality?
 
 ## Zend Server Z-Ray
 
-[Zend Server](https://www.zend.com/en/products/laminas_server) ships with a tool
+[Zend Server](https://www.zend.com/products/zend-server) ships with a tool
 called [Z-Ray](https://www.zend.com/en/products/server/z-ray), which provides
 both a debug toolbar and debug console (for API debugging). Z-Ray is also
 currently [available as a standalone technology
@@ -18,7 +18,7 @@ When using Zend Server or the standalone Z-Ray, you do not need to make any
 changes to your application whatsoever to benefit from it; you simply need to
 make sure Z-Ray is enabled and/or that you've setup a security token to
 selectively enable it on-demand. See the
-[Z-Ray documentation](http://files.zend.com/help/Laminas-Server/content/z-ray_concept.htm)
+[Z-Ray documentation](http://files.zend.com/help/Zend-Server/content/z-ray_concept.htm)
 for full usage details.
 
 ## bitExpert/prophiler-psr7-middleware
@@ -36,7 +36,7 @@ $ composer require bitExpert/prophiler-psr7-middleware
 
 From there, you will need to create a factory for the middleware, and add it to
 your middleware pipeline. Stephan Hochdörfer, author of the package, has written
-a [post detailing these steps](https://blog.bitexpert.de/blog/using-prophiler-with-mezzio/).
+a [post detailing these steps](https://blog.bitexpert.de/blog/prophiler-psr-7-middleware/).
 
 > ### Use locally!
 >

--- a/docs/book/v2/cookbook/flash-messengers.md
+++ b/docs/book/v2/cookbook/flash-messengers.md
@@ -145,9 +145,9 @@ function($request, DelegateInterface $delegate)
 
 From there, it's a matter of providing the flash messages to your template.
 
-## damess/mezzio-session-middleware and Aura.Session
+## damess/expressive-session-middleware and Aura.Session
 
-[damess/mezzio-session-middleware](https://github.com/dannym87/mezzio-session-middleware)
+[damess/mezzio-session-middleware](https://github.com/dannym87/expressive-session-middleware)
 provides middleware for initializing an
 [Aura.Session](https://github.com/auraphp/Aura.Session) instance; Aura.Session
 provides flash messaging capabilities as part of its featureset.

--- a/docs/book/v2/features/container/aura-di.md
+++ b/docs/book/v2/features/container/aura-di.md
@@ -23,7 +23,7 @@ $ composer require aura/di
 ## Configuration
 
 Aura.Di can help you to organize your code better with
-[ContainerConfig classes](http://auraphp.com/packages/Aura.Di/config.html) and
+[ContainerConfig classes](http://auraphp.com/packages/4.x/Di/config.html) and
 [two step configuration](http://auraphp.com/blog/2014/04/07/two-stage-config/).
 In this example, we'll put that in `config/container.php`:
 

--- a/docs/book/v2/features/router/intro.md
+++ b/docs/book/v2/features/router/intro.md
@@ -113,4 +113,4 @@ Mezzio currently ships with adapters for the following routers:
 
 - [Aura.Router](aura.md)
 - [FastRoute](fast-route.md)
-- [laminas-mvc Router](laminas.md)
+- [laminas-mvc Router](laminas-router.md)

--- a/docs/book/v2/index.md
+++ b/docs/book/v2/index.md
@@ -14,7 +14,7 @@ framework for PHP, with the following features:
 - Optionally, templating. We support:
     - [Plates](http://platesphp.com/)
     - [Twig](http://twig.sensiolabs.org/)
-    - [Laminas's PhpRenderer](https://docs.laminaseframework..com/laminas-view/)
+    - [Laminas's PhpRenderer](https://docs.laminas.dev/laminas-view/)
 - Error handling. Create templated error pages, or use tools like
   [whoops](https://github.com/filp/whoops) for debugging purposes.
 - Nested middleware applications. Write an application, and compose it later

--- a/docs/book/v2/reference/mezzio-projects.md
+++ b/docs/book/v2/reference/mezzio-projects.md
@@ -6,13 +6,12 @@ mezzio.
 
 ## Sample Code & Tutorials
 
-- Mezzio Tutorial (WIP) - [*source*](https://github.com/RalfEggert/mezzio-tutorial)
-- [AstroSplash](http://www.sitepoint.com/build-nasa-photo-gallery-mezzio/) - [*source*](https://github.com/AndrewCarterUK/AstroSplash)
+- Expressive Tutorial (WIP) - [*source*](https://github.com/RalfEggert/zend-expressive-tutorial)
+- [AstroSplash](http://www.sitepoint.com/build-nasa-photo-gallery-zend-expressive/) - [*source*](https://github.com/AndrewCarterUK/AstroSplash)
 - [php-ddd-cargo-sample](https://codeliner.github.io/php-ddd-cargo-sample/) - [*source*](https://github.com/codeliner/php-ddd-cargo-sample)
 
 ## Personal Sites
 
 - [mwop.net](https://mwop.net/) - [*source*](https://github.com/weierophinney/mwop.net)
-- [xtreamwayz.com](https://xtreamwayz.com/) - [*source*](https://github.com/xtreamwayz/xtreamwayz.com)
-- [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/website-mezzio)
+- [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/alejandrocelaya.com)
 - [zimuel.it](http://www.zimuel.it) - [*source*](https://github.com/ezimuel/zimuel.it)

--- a/docs/book/v2/why-mezzio.md
+++ b/docs/book/v2/why-mezzio.md
@@ -13,7 +13,7 @@ decisions need be made up front; developers know where new code goes, and how it
 will wire into the overall application.
 
 Additionally, a number of training courses exist, including [offerings by
-Laminas](https://www.zend.com/en/services/training/api-tools-fundamentals-i), allowing you
+Zend](https://www.zend.com/training/zf-fundamentals), allowing you
 or your team to fully learn the framework and take advantage of all its features.
 
 Finally, laminas-mvc has a lively [module ecosystem](https://packagist.org/search/?q=laminas),

--- a/docs/book/v3/cookbook/debug-toolbars.md
+++ b/docs/book/v3/cookbook/debug-toolbars.md
@@ -7,7 +7,7 @@ As an Mezzio user, how can you get similar functionality?
 
 ## Zend Server Z-Ray
 
-[Zend Server](https://www.zend.com/en/products/laminas_server) ships with a tool
+[Zend Server](https://www.zend.com/products/zend-server) ships with a tool
 called [Z-Ray](https://www.zend.com/en/products/server/z-ray), which provides
 both a debug toolbar and debug console (for API debugging). Z-Ray is also
 currently [available as a standalone technology
@@ -18,7 +18,7 @@ When using Zend Server or the standalone Z-Ray, you do not need to make any
 changes to your application whatsoever to benefit from it; you simply need to
 make sure Z-Ray is enabled and/or that you've setup a security token to
 selectively enable it on-demand. See the
-[Z-Ray documentation](http://files.zend.com/help/Laminas-Server/content/z-ray_concept.htm)
+[Z-Ray documentation](http://files.zend.com/help/Zend-Server/content/z-ray_concept.htm)
 for full usage details.
 
 ## php-middleware/php-debug-bar

--- a/docs/book/v3/cookbook/double-pass-middleware.md
+++ b/docs/book/v3/cookbook/double-pass-middleware.md
@@ -165,7 +165,7 @@ awareness of double-pass middleware, and have it auto-decorate them for you.
 
 A contributor has created such a library:
 
-- https://github.com/Moln/mezzio-callable-middleware-compat
+- https://github.com/Moln/expressive-callable-middleware-compat
 
 You can install it using `composer require moln/mezzio-callable-middleware-compat`.
 Once installed, add its `Moln\MezzioCallableCompat\ConfigProvider` as an

--- a/docs/book/v3/features/router/intro.md
+++ b/docs/book/v3/features/router/intro.md
@@ -118,4 +118,4 @@ Mezzio currently ships with adapters for the following routers:
 
 - [Aura.Router](aura.md)
 - [FastRoute](fast-route.md)
-- [laminas-mvc Router](laminas.md)
+- [laminas-mvc Router](laminas-router.md)

--- a/docs/book/v3/features/template/plates.md
+++ b/docs/book/v3/features/template/plates.md
@@ -90,7 +90,7 @@ mezzio-plates provides the following extensions.
 ### UrlExtension
 
 `Mezzio\Plates\Extension\UrlExtension` composes each of the
-[UrlHelper](../helpers/url-helper.md) and [ServerUrlHelper](../helpers/server-url-helper),
+[UrlHelper](../helpers/url-helper.md) and [ServerUrlHelper](../helpers/server-url-helper.md),
 and provides the following template methods:
 
 ```php

--- a/docs/book/v3/index.md
+++ b/docs/book/v3/index.md
@@ -14,7 +14,7 @@ framework for PHP, with the following features:
 - Optionally, templating. We support:
     - [Plates](http://platesphp.com/)
     - [Twig](http://twig.sensiolabs.org/)
-    - [laminas-view's PhpRenderer](https://docs.laminaseframework..com/laminas-view/)
+    - [laminas-view's PhpRenderer](https://docs.laminas.dev/laminas-view/)
 - Error handling. Create templated error pages, or use tools like
   [whoops](https://github.com/filp/whoops) for debugging purposes.
 - Nested middleware applications. Write an application, and compose it later

--- a/docs/book/v3/reference/mezzio-projects.md
+++ b/docs/book/v3/reference/mezzio-projects.md
@@ -6,15 +6,14 @@ mezzio.
 
 ## Sample Code & Tutorials
 
-- Mezzio Tutorial (WIP) - [*source*](https://github.com/RalfEggert/mezzio-tutorial)
-- [AstroSplash](http://www.sitepoint.com/build-nasa-photo-gallery-mezzio/) - [*source*](https://github.com/AndrewCarterUK/AstroSplash)
+- Expressive Tutorial (WIP) - [*source*](https://github.com/RalfEggert/zend-expressive-tutorial)
+- [AstroSplash](http://www.sitepoint.com/build-nasa-photo-gallery-zend-expressive/) - [*source*](https://github.com/AndrewCarterUK/AstroSplash)
 - [php-ddd-cargo-sample](https://codeliner.github.io/php-ddd-cargo-sample/) - [*source*](https://github.com/codeliner/php-ddd-cargo-sample)
 
 ## Personal Sites
 
 - [mwop.net](https://mwop.net/) - [*source*](https://github.com/weierophinney/mwop.net)
-- [xtreamwayz.com](https://xtreamwayz.com/) - [*source*](https://github.com/xtreamwayz/xtreamwayz.com)
-- [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/website-mezzio)
+- [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/alejandrocelaya.com)
 - [zimuel.it](http://www.zimuel.it) - [*source*](https://github.com/ezimuel/zimuel.it)
 
 ## Applications

--- a/docs/book/v3/why-mezzio.md
+++ b/docs/book/v3/why-mezzio.md
@@ -13,7 +13,7 @@ decisions need be made up front; developers know where new code goes, and how it
 will wire into the overall application.
 
 Additionally, a number of training courses exist, including [offerings by
-Laminas](https://www.zend.com/en/services/training/api-tools-fundamentals-i), allowing you
+Zend](https://www.zend.com/training/zf-fundamentals), allowing you
 or your team to fully learn the framework and take advantage of all its features.
 
 Finally, laminas-mvc has a lively [module ecosystem](https://packagist.org/search/?q=laminas),


### PR DESCRIPTION
|    Q        |   A
|------------ | ------
| Bugfix      | yes

### Description

The transfer from ZF to Laminas introduces some problems in names and links of the documentation.
This means we must check all other repositories with documentations.

This pull request also contains fixes for wrong links to Markdown and images files and also a removal of the website from @xtreamwayz.

([markdown-link-check](https://github.com/tcort/markdown-link-check) was used for finding broken links.)

/cc @weierophinney @michalbundyra 