### PR TITLE
clean up: remove manual addition of Diactoros service in debug toolbar cookbook

### DIFF
--- a/docs/book/v3/cookbook/debug-toolbars.md
+++ b/docs/book/v3/cookbook/debug-toolbars.md
@@ -91,7 +91,10 @@ return [
 ];
 ```
 
-Start from [Diactoros](https://docs.laminas.dev/laminas-diactoros) `^2.3.0`, you can register above Psr-17 services by add `\Laminas\Diactoros\ConfigProvider::class` to config.
+> Starting with [Diactoros](https://docs.laminas.dev/laminas-diactoros) 2.3.0, you
+> can register the above PSR-17 services by adding an entry for
+> `\Laminas\Diactoros\ConfigProvider::class` to your `config/config.php` file,
+> if it is not added for you during installation.
 
 Finally, add the `PhpDebugBarMiddleware` class to the pipeline in
 `config/pipeline.php` after piping the `ErrorHandler` class:

--- a/docs/book/v3/cookbook/debug-toolbars.md
+++ b/docs/book/v3/cookbook/debug-toolbars.md
@@ -69,7 +69,7 @@ return array_merge(ConfigProvider::getConfig(), [
 ]);
 ```
 
-In addition, ensure the [PSR-17 HTTP message factory interfaces](https://www.php-fig.org/psr/psr-15/)
+In addition, ensure the [PSR-17 HTTP message factory interfaces](https://www.php-fig.org/psr/psr-17/)
 are registered in your container. For example, when using
 [Diactoros](https://docs.laminas.dev/laminas-diactoros) as your
 [PSR-7 HTTP message interfaces](https://www.php-fig.org/psr/psr-7)

--- a/docs/book/v3/cookbook/debug-toolbars.md
+++ b/docs/book/v3/cookbook/debug-toolbars.md
@@ -69,7 +69,7 @@ return array_merge(ConfigProvider::getConfig(), [
 ]);
 ```
 
-In addition, ensure the [PSR-15 HTTP message factory interfaces](https://www.php-fig.org/psr/psr-15/)
+In addition, ensure the [PSR-17 HTTP message factory interfaces](https://www.php-fig.org/psr/psr-15/)
 are registered in your container. For example, when using
 [Diactoros](https://docs.laminas.dev/laminas-diactoros) as your
 [PSR-7 HTTP message interfaces](https://www.php-fig.org/psr/psr-7)
@@ -90,6 +90,8 @@ return [
         // ...
 ];
 ```
+
+Start from [Diactoros](https://docs.laminas.dev/laminas-diactoros) `^2.3.0`, you can register above Psr-17 services by add `\Laminas\Diactoros\ConfigProvider::class` to config.
 
 Finally, add the `PhpDebugBarMiddleware` class to the pipeline in
 `config/pipeline.php` after piping the `ErrorHandler` class:


### PR DESCRIPTION
Due to addition of Diactoros ConfigProvider in mezzio/mezzio-skeleton#21

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes