### PR TITLE
Upgraded PHPUnit to version 9.3.0, PHPStan to version 0.12.0 and bumped the minimum version to PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
     - php: 7.4
       env:
         - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,25 +12,16 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-        - PHPSTAN_CHECK=true
     - php: 7.3
       env:
         - DEPS=lowest
     - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
       env:
         - DEPS=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
       env:
         - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "fig/http-message-util": "^1.1.2",
         "laminas/laminas-httphandlerrunner": "^1.0.1",
         "laminas/laminas-stratigility": "^3.0",
@@ -51,9 +51,10 @@
         "mezzio/mezzio-fastroute": "^3.0",
         "mezzio/mezzio-laminasrouter": "^3.0",
         "mockery/mockery": "^1.0",
-        "phpstan/phpstan": "^0.9.2",
-        "phpstan/phpstan-strict-rules": "^0.9",
-        "phpunit/phpunit": "^7.0.1"
+        "phpstan/phpstan": "^0.12.0",
+        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpunit/phpunit": "^9.3.0",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0",

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -21,6 +21,7 @@ use Mezzio\Router\RouteCollector;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -33,7 +34,9 @@ use function strtoupper;
 
 class ApplicationTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait, AttributeAssertionTrait;
+
+    public function setUp(): void
     {
         $this->factory = $this->prophesize(MiddlewareFactory::class);
         $this->pipeline = $this->prophesize(MiddlewarePipeInterface::class);
@@ -124,9 +127,9 @@ class ApplicationTest extends TestCase
 
         $this->pipeline
             ->pipe(Argument::that(function ($test) use ($preparedMiddleware) {
-                Assert::assertInstanceOf(PathMiddlewareDecorator::class, $test);
-                Assert::assertAttributeSame('/foo', 'prefix', $test);
-                Assert::assertAttributeSame($preparedMiddleware, 'middleware', $test);
+                $this->assertInstanceOf(PathMiddlewareDecorator::class, $test);
+                $this->assertAttributeSame('/foo', 'prefix', $test);
+                $this->assertAttributeSame($preparedMiddleware, 'middleware', $test);
                 return $test;
             }))
             ->shouldBeCalled();

--- a/test/AttributeAssertionTrait.php
+++ b/test/AttributeAssertionTrait.php
@@ -9,68 +9,48 @@ use ReflectionClass;
 
 trait AttributeAssertionTrait
 {
-    protected function assertAttributeSame($expected, string $actualAttributeName, object $actualClassOrObject): void
+    protected function assertAttributeSame($expected, string $attributeName, object $object): void
     {
-        $reflectionClass = new ReflectionClass($actualClassOrObject);
-
-        $property = $reflectionClass->getProperty($actualAttributeName);
-        $property->setAccessible(true);
-
-        $this->assertSame($expected, $property->getValue($actualClassOrObject));
+        $this->assertSame($expected, $this->getInternalProperty($attributeName, $object));
     }
 
-    protected function assertAttributeNotSame($expected, string $actualAttributeName, object $actualClassOrObject): void
+    protected function assertAttributeNotSame($expected, string $attributeName, object $object): void
     {
-        $reflectionClass = new ReflectionClass($actualClassOrObject);
-
-        $property = $reflectionClass->getProperty($actualAttributeName);
-        $property->setAccessible(true);
-
-        $this->assertNotSame($expected, $property->getValue($actualClassOrObject));
+        $this->assertNotSame($expected, $this->getInternalProperty($attributeName, $object));
     }
 
-    protected function assertAttributeEquals($expected, string $actualAttributeName, object $actualClassOrObject): void
+    protected function assertAttributeEquals($expected, string $attributeName, object $object): void
     {
-        $reflectionClass = new ReflectionClass($actualClassOrObject);
-
-        $property = $reflectionClass->getProperty($actualAttributeName);
-        $property->setAccessible(true);
-
-        $this->assertEquals($expected, $property->getValue($actualClassOrObject));
+        $this->assertEquals($expected, $this->getInternalProperty($attributeName, $object));
     }
 
-    protected function assertAttributeEmpty(string $haystackAttributeName, $haystackClassOrObject): void
+    protected function assertAttributeInstanceOf(string $expected, string $attributeName, object $object): void
     {
-        $reflectionClass = new ReflectionClass($haystackClassOrObject);
-
-        $property = $reflectionClass->getProperty($haystackAttributeName);
-        $property->setAccessible(true);
-
-        $this->assertEmpty($property->getValue($haystackClassOrObject));
+        $this->assertInstanceOf($expected, $this->getInternalProperty($attributeName, $object));
     }
 
-    protected function assertAttributeInstanceOf(string $expected, string $attributeName, $classOrObject): void
+    protected function assertAttributeInternalType(string $expected, string $attributeName, object $object): void
     {
-        $reflectionClass = new ReflectionClass($classOrObject);
-
-        $property = $reflectionClass->getProperty($attributeName);
-        $property->setAccessible(true);
-
-        $this->assertInstanceOf($expected, $property->getValue($classOrObject));
+        $this->assertInternalType($expected, $this->getInternalProperty($attributeName, $object));
     }
 
-    protected function assertAttributeInternalType(string $expected, string $attributeName, $classOrObject): void
+    protected function assertAttributeEmpty(string $attributeName, object $object): void
     {
-        $reflectionClass = new ReflectionClass($classOrObject);
-
-        $property = $reflectionClass->getProperty($attributeName);
-        $property->setAccessible(true);
-
-        $this->assertInternalType($expected, $property->getValue($classOrObject));
+        $this->assertEmpty($this->getInternalProperty($attributeName, $object));
     }
 
     protected function assertInternalType(string $expected, $actual): void
     {
         $this->assertThat($actual, new IsType($expected));
+    }
+
+    private function getInternalProperty(string $attributeName, object $object)
+    {
+        $reflectionClass = new ReflectionClass($object);
+
+        $property = $reflectionClass->getProperty($attributeName);
+        $property->setAccessible(true);
+
+        return $property->getValue($object);
     }
 }

--- a/test/AttributeAssertionTrait.php
+++ b/test/AttributeAssertionTrait.php
@@ -1,5 +1,11 @@
 <?php
 
+/**
+ * @see       https://github.com/mezzio/mezzio for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio/blob/master/LICENSE.md New BSD License
+ */
+
 declare(strict_types=1);
 
 namespace MezzioTest;

--- a/test/AttributeAssertionTrait.php
+++ b/test/AttributeAssertionTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest;
+
+use PHPUnit\Framework\Constraint\IsType;
+use ReflectionClass;
+
+trait AttributeAssertionTrait
+{
+    protected function assertAttributeSame($expected, string $actualAttributeName, object $actualClassOrObject): void
+    {
+        $reflectionClass = new ReflectionClass($actualClassOrObject);
+
+        $property = $reflectionClass->getProperty($actualAttributeName);
+        $property->setAccessible(true);
+
+        $this->assertSame($expected, $property->getValue($actualClassOrObject));
+    }
+
+    protected function assertAttributeNotSame($expected, string $actualAttributeName, object $actualClassOrObject): void
+    {
+        $reflectionClass = new ReflectionClass($actualClassOrObject);
+
+        $property = $reflectionClass->getProperty($actualAttributeName);
+        $property->setAccessible(true);
+
+        $this->assertNotSame($expected, $property->getValue($actualClassOrObject));
+    }
+
+    protected function assertAttributeEquals($expected, string $actualAttributeName, object $actualClassOrObject): void
+    {
+        $reflectionClass = new ReflectionClass($actualClassOrObject);
+
+        $property = $reflectionClass->getProperty($actualAttributeName);
+        $property->setAccessible(true);
+
+        $this->assertEquals($expected, $property->getValue($actualClassOrObject));
+    }
+
+    protected function assertAttributeEmpty(string $haystackAttributeName, $haystackClassOrObject): void
+    {
+        $reflectionClass = new ReflectionClass($haystackClassOrObject);
+
+        $property = $reflectionClass->getProperty($haystackAttributeName);
+        $property->setAccessible(true);
+
+        $this->assertEmpty($property->getValue($haystackClassOrObject));
+    }
+
+    protected function assertAttributeInstanceOf(string $expected, string $attributeName, $classOrObject): void
+    {
+        $reflectionClass = new ReflectionClass($classOrObject);
+
+        $property = $reflectionClass->getProperty($attributeName);
+        $property->setAccessible(true);
+
+        $this->assertInstanceOf($expected, $property->getValue($classOrObject));
+    }
+
+    protected function assertAttributeInternalType(string $expected, string $attributeName, $classOrObject): void
+    {
+        $reflectionClass = new ReflectionClass($classOrObject);
+
+        $property = $reflectionClass->getProperty($attributeName);
+        $property->setAccessible(true);
+
+        $this->assertInternalType($expected, $property->getValue($classOrObject));
+    }
+
+    protected function assertInternalType(string $expected, $actual): void
+    {
+        $this->assertThat($actual, new IsType($expected));
+    }
+}

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -25,6 +25,7 @@ use Mezzio\MiddlewareFactory;
 use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -43,10 +44,12 @@ use const Mezzio\ROUTE_MIDDLEWARE;
 
 class ConfigProviderTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     /** @var ConfigProvider */
     private $provider;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -29,6 +29,7 @@ use MezzioTest\ContainerTrait;
 use MezzioTest\TestAsset\InvokableMiddleware;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -40,7 +41,7 @@ use function array_shift;
 
 class ApplicationConfigInjectionDelegatorTest extends TestCase
 {
-    use ContainerTrait;
+    use ContainerTrait, ProphecyTrait;
 
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
@@ -60,7 +61,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
     /** @var RouterInterface|ObjectProphecy */
     private $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->mockContainerInterface();
         $this->router = $this->prophesize(RouterInterface::class);

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -17,11 +17,15 @@ use Mezzio\ApplicationPipeline;
 use Mezzio\Container\ApplicationFactory;
 use Mezzio\MiddlewareFactory;
 use Mezzio\Router\RouteCollector;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class ApplicationFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryProducesAnApplication()
     {
         $middlewareFactory = $this->prophesize(MiddlewareFactory::class)->reveal();

--- a/test/Container/EmitterFactoryTest.php
+++ b/test/Container/EmitterFactoryTest.php
@@ -13,6 +13,7 @@ namespace Mezzio\Container;
 use Laminas\HttpHandlerRunner\Emitter\EmitterStack;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 use function array_shift;
@@ -20,6 +21,8 @@ use function iterator_to_array;
 
 class EmitterFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testFactoryProducesEmitterStackWithSapiEmitterComposed()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Container/ErrorHandlerFactoryTest.php
+++ b/test/Container/ErrorHandlerFactoryTest.php
@@ -15,7 +15,9 @@ use Laminas\Stratigility\Middleware\ErrorHandler;
 use Laminas\Stratigility\Middleware\ErrorResponseGenerator as StratigilityGenerator;
 use Mezzio\Container\ErrorHandlerFactory;
 use Mezzio\Middleware\ErrorResponseGenerator;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -24,10 +26,12 @@ use TypeError;
 
 class ErrorHandlerFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
     }

--- a/test/Container/ErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ErrorResponseGeneratorFactoryTest.php
@@ -13,19 +13,23 @@ namespace MezzioTest\Container;
 use Mezzio\Container\ErrorResponseGeneratorFactory;
 use Mezzio\Middleware\ErrorResponseGenerator;
 use Mezzio\Template\TemplateRendererInterface;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 
 class ErrorResponseGeneratorFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
     /** @var TemplateRendererInterface|ObjectProphecy */
     private $renderer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->renderer  = $this->prophesize(TemplateRendererInterface::class);

--- a/test/Container/MiddlewareContainerFactoryTest.php
+++ b/test/Container/MiddlewareContainerFactoryTest.php
@@ -12,11 +12,15 @@ namespace MezzioTest\Container;
 
 use Mezzio\Container\MiddlewareContainerFactory;
 use Mezzio\MiddlewareContainer;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class MiddlewareContainerFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryCreatesMiddlewareContainerUsingProvidedContainer()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Container/MiddlewareFactoryFactoryTest.php
+++ b/test/Container/MiddlewareFactoryFactoryTest.php
@@ -13,11 +13,15 @@ namespace MezzioTest\Container;
 use Mezzio\Container\MiddlewareFactoryFactory;
 use Mezzio\MiddlewareContainer;
 use Mezzio\MiddlewareFactory;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class MiddlewareFactoryFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryProducesMiddlewareFactoryComposingMiddlewareContainerInstance()
     {
         $middlewareContainer = $this->prophesize(MiddlewareContainer::class)->reveal();

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -13,20 +13,24 @@ namespace MezzioTest\Container;
 use Mezzio\Container\NotFoundHandlerFactory;
 use Mezzio\Handler\NotFoundHandler;
 use Mezzio\Template\TemplateRendererInterface;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
 class NotFoundHandlerFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
     /** @var ResponseInterface|ObjectProphecy */
     private $response;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->response = $this->prophesize(ResponseInterface::class)->reveal();
         $this->container = $this->prophesize(ContainerInterface::class);

--- a/test/Container/RequestHandlerRunnerFactoryTest.php
+++ b/test/Container/RequestHandlerRunnerFactoryTest.php
@@ -15,8 +15,10 @@ use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Mezzio\ApplicationPipeline;
 use Mezzio\Container\RequestHandlerRunnerFactory;
 use Mezzio\Response\ServerRequestErrorResponseGenerator;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -27,6 +29,8 @@ use Throwable;
 
 class RequestHandlerRunnerFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryProducesRunnerUsingServicesFromContainer()
     {
         $container = $this->prophesize(ContainerInterface::class);

--- a/test/Container/ResponseFactoryFactoryTest.php
+++ b/test/Container/ResponseFactoryFactoryTest.php
@@ -12,11 +12,15 @@ namespace MezzioTest\Container;
 
 use Laminas\Diactoros\Response;
 use Mezzio\Container\ResponseFactoryFactory;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class ResponseFactoryFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryProducesACallableCapableOfGeneratingAResponseWhenDiactorosIsInstalled()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
@@ -13,6 +13,7 @@ namespace MezzioTest\Container;
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\ResponseFactoryFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 
@@ -23,6 +24,8 @@ use function spl_autoload_unregister;
 
 class ResponseFactoryFactoryWithoutDiactorosTest extends TestCase
 {
+    use ProphecyTrait;
+    
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
@@ -32,7 +35,7 @@ class ResponseFactoryFactoryWithoutDiactorosTest extends TestCase
     /** @var array */
     private $autoloadFunctions = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         class_exists(InvalidServiceException::class);
 

--- a/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
@@ -25,7 +25,7 @@ use function spl_autoload_unregister;
 class ResponseFactoryFactoryWithoutDiactorosTest extends TestCase
 {
     use ProphecyTrait;
-    
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 

--- a/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
@@ -14,13 +14,17 @@ use Closure;
 use Mezzio\Container\ServerRequestErrorResponseGeneratorFactory;
 use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use Mezzio\Template\TemplateRendererInterface;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 
 class ServerRequestErrorResponseGeneratorFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryOnlyRequiresResponseService()
     {
         $container = $this->prophesize(ContainerInterface::class);

--- a/test/Container/ServerRequestFactoryFactoryTest.php
+++ b/test/Container/ServerRequestFactoryFactoryTest.php
@@ -13,11 +13,15 @@ namespace MezzioTest\Container;
 use Closure;
 use Laminas\Diactoros\ServerRequestFactory;
 use Mezzio\Container\ServerRequestFactoryFactory;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class ServerRequestFactoryFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryReturnsCallable()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php
@@ -13,6 +13,7 @@ namespace MezzioTest\Container;
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\ServerRequestFactoryFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 
@@ -23,6 +24,8 @@ use function spl_autoload_unregister;
 
 class ServerRequestFactoryFactoryWithoutDiactorosTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
@@ -32,7 +35,7 @@ class ServerRequestFactoryFactoryWithoutDiactorosTest extends TestCase
     /** @var array */
     private $autoloadFunctions = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         class_exists(InvalidServiceException::class);
 

--- a/test/Container/StreamFactoryFactoryTest.php
+++ b/test/Container/StreamFactoryFactoryTest.php
@@ -12,11 +12,15 @@ namespace MezzioTest\Container;
 
 use Laminas\Diactoros\Stream;
 use Mezzio\Container\StreamFactoryFactory;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class StreamFactoryFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     public function testFactoryProducesACallableCapableOfGeneratingAStreamWhenDiactorosIsInstalled()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();

--- a/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
@@ -13,6 +13,7 @@ namespace MezzioTest\Container;
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\StreamFactoryFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 
@@ -23,6 +24,8 @@ use function spl_autoload_unregister;
 
 class StreamFactoryFactoryWithoutDiactorosTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
@@ -32,7 +35,7 @@ class StreamFactoryFactoryWithoutDiactorosTest extends TestCase
     /** @var array */
     private $autoloadFunctions = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         class_exists(InvalidServiceException::class);
 

--- a/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
@@ -12,7 +12,9 @@ namespace MezzioTest\Container;
 
 use Mezzio\Container\WhoopsErrorResponseGeneratorFactory;
 use Mezzio\Middleware\WhoopsErrorResponseGenerator;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Whoops\Run;
@@ -22,13 +24,15 @@ use function interface_exists;
 
 class WhoopsErrorResponseGeneratorFactoryTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
     /** @var Run|RunInterface|ObjectProphecy */
     private $whoops;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
 

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -11,8 +11,10 @@ declare(strict_types=1);
 namespace MezzioTest\Container;
 
 use Mezzio\Container\WhoopsFactory;
+use MezzioTest\AttributeAssertionTrait;
 use MezzioTest\ContainerTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
@@ -30,7 +32,7 @@ use function sprintf;
  */
 class WhoopsFactoryTest extends TestCase
 {
-    use ContainerTrait;
+    use ContainerTrait, ProphecyTrait, AttributeAssertionTrait;
 
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
@@ -38,7 +40,7 @@ class WhoopsFactoryTest extends TestCase
     /** @var WhoopsFactory */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $pageHandler     = $this->prophesize(PrettyPageHandler::class);
         $this->container = $this->mockContainerInterface();

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -12,8 +12,10 @@ namespace MezzioTest\Container;
 
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\WhoopsPageHandlerFactory;
+use MezzioTest\AttributeAssertionTrait;
 use MezzioTest\ContainerTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Whoops\Handler\PrettyPageHandler;
@@ -23,7 +25,7 @@ use Whoops\Handler\PrettyPageHandler;
  */
 class WhoopsPageHandlerFactoryTest extends TestCase
 {
-    use ContainerTrait;
+    use ContainerTrait, ProphecyTrait, AttributeAssertionTrait;
 
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
@@ -31,7 +33,7 @@ class WhoopsPageHandlerFactoryTest extends TestCase
     /** @var WhoopsPageHandlerFactory */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->mockContainerInterface();
         $this->factory   = new WhoopsPageHandlerFactory();

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -43,7 +43,7 @@ class ExceptionTest extends TestCase
      */
     public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        $this->assertContains('Exception', $exception);
+        $this->assertStringContainsString('Exception', $exception);
         $this->assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -14,7 +14,9 @@ use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Mezzio\Handler\NotFoundHandler;
 use Mezzio\Template\TemplateRendererInterface;
+use MezzioTest\AttributeAssertionTrait;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,6 +25,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class NotFoundHandlerTest extends TestCase
 {
+    use ProphecyTrait, AttributeAssertionTrait;
+
     /** @var ServerRequestInterface|ObjectProphecy */
     private $request;
 
@@ -32,7 +36,7 @@ class NotFoundHandlerTest extends TestCase
     /** @var callable */
     private $responseFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request  = $this->prophesize(ServerRequestInterface::class);
         $this->response = $this->prophesize(ResponseInterface::class);

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -15,6 +15,7 @@ use Mezzio\Middleware\ErrorResponseGenerator;
 use Mezzio\Template\TemplateRendererInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -23,6 +24,8 @@ use RuntimeException;
 
 class ErrorResponseGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ServerRequestInterface|ObjectProphecy */
     private $request;
 
@@ -32,7 +35,7 @@ class ErrorResponseGeneratorTest extends TestCase
     /** @var TemplateRendererInterface|ObjectProphecy */
     private $renderer;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->request  = $this->prophesize(ServerRequestInterface::class);
         $this->stream   = $this->prophesize(StreamInterface::class);
@@ -91,9 +94,9 @@ class ErrorResponseGeneratorTest extends TestCase
 
         $this->stream
             ->write(Argument::that(function ($body) use ($leaf, $branch, $error) {
-                $this->assertContains($leaf->getTraceAsString(), $body);
-                $this->assertContains($branch->getTraceAsString(), $body);
-                $this->assertContains($error->getTraceAsString(), $body);
+                $this->assertStringContainsString($leaf->getTraceAsString(), $body);
+                $this->assertStringContainsString($branch->getTraceAsString(), $body);
+                $this->assertStringContainsString($error->getTraceAsString(), $body);
                 return true;
             }))
             ->shouldBeCalled();

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -14,6 +14,7 @@ use Mezzio\Exception\InvalidMiddlewareException;
 use Mezzio\Middleware\LazyLoadingMiddleware;
 use Mezzio\MiddlewareContainer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -22,6 +23,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class LazyLoadingMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var MiddlewareContainer|ObjectProphecy */
     private $container;
 
@@ -31,7 +34,7 @@ class LazyLoadingMiddlewareTest extends TestCase
     /** @var RequestHandlerInterface|ObjectProphecy */
     private $handler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(MiddlewareContainer::class);
         $this->request   = $this->prophesize(ServerRequestInterface::class);

--- a/test/Middleware/WhoopsErrorResponseGeneratorTest.php
+++ b/test/Middleware/WhoopsErrorResponseGeneratorTest.php
@@ -14,6 +14,7 @@ use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use InvalidArgumentException;
 use Mezzio\Middleware\WhoopsErrorResponseGenerator;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,6 +31,8 @@ use function method_exists;
 
 class WhoopsErrorResponseGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var Run|RunInterface|ObjectProphecy */
     private $whoops;
 
@@ -42,7 +45,7 @@ class WhoopsErrorResponseGeneratorTest extends TestCase
     /** @var StreamInterface|ObjectProphecy */
     private $stream;
 
-    public function setUp()
+    public function setUp(): void
     {
         // Run is marked final in 2.X, but in that version, we can mock the
         // RunInterface. 1.X has only Run, and it is not final.

--- a/test/MiddlewareContainerTest.php
+++ b/test/MiddlewareContainerTest.php
@@ -15,13 +15,16 @@ use Mezzio\Exception;
 use Mezzio\MiddlewareContainer;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class MiddlewareContainerTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait, AttributeAssertionTrait;
+
+    public function setUp(): void
     {
         $this->originContainer = $this->prophesize(ContainerInterface::class);
         $this->container = new MiddlewareContainer($this->originContainer->reveal());

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -19,6 +19,7 @@ use Mezzio\MiddlewareContainer;
 use Mezzio\MiddlewareFactory;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionProperty;
@@ -28,7 +29,9 @@ use function iterator_to_array;
 
 class MiddlewareFactoryTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait, AttributeAssertionTrait;
+
+    public function setUp(): void
     {
         $this->container = $this->prophesize(MiddlewareContainer::class);
         $this->factory = new MiddlewareFactory($this->container->reveal());

--- a/test/Response/ServerRequestErrorResponseGeneratorTest.php
+++ b/test/Response/ServerRequestErrorResponseGeneratorTest.php
@@ -14,6 +14,7 @@ use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use Mezzio\Template\TemplateRendererInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -24,6 +25,8 @@ use function strpos;
 
 class ServerRequestErrorResponseGeneratorTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var TemplateRendererInterface|ObjectProphecy */
     private $renderer;
 
@@ -33,7 +36,7 @@ class ServerRequestErrorResponseGeneratorTest extends TestCase
     /** @var callable */
     private $responseFactory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response = $this->prophesize(ResponseInterface::class);
         $this->responseFactory = function () {

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -33,6 +33,7 @@ use Mezzio\Router\RouterInterface;
 use MezzioTest\ContainerTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -42,7 +43,7 @@ use function sprintf;
 
 class IntegrationTest extends TestCase
 {
-    use ContainerTrait;
+    use ContainerTrait, ProphecyTrait;
 
     /** @var Response */
     private $response;
@@ -56,7 +57,7 @@ class IntegrationTest extends TestCase
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->response  = new Response();
         $this->responseFactory = function () {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Upgraded PHPUnit to version 9.3.0, PHPStan to version 0.12.0 and bumped the minimum version to PHP 7.3