### PR TITLE
PHP 8.0 compatiblity and dependency upgrades.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,14 @@ matrix:
     - php: 7.4
       env:
         - DEPS=latest
+    - php: 8.0
+      env:
+        - DEPS=lowest
+        - COMPOSER_ARGS=--ignore-platform-reqs
+    - php: 8.0
+      env:
+        - DEPS=latest
+        - COMPOSER_ARGS=--ignore-platform-reqs
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "laminas/laminas-stratigility": "^3.3.0",
         "laminas/laminas-zendframework-bridge": "^1.1.0",
         "mezzio/mezzio-router": "^3.2.0",
-        "mezzio/mezzio-template": "^2.0",
+        "mezzio/mezzio-template": "^2.1.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "laminas/laminas-servicemanager": "^3.6.0",
         "malukenho/docheader": "^0.1.8",
         "mezzio/mezzio-aurarouter": "^3.0",
-        "mezzio/mezzio-fastroute": "^3.0",
+        "mezzio/mezzio-fastroute": "^3.1.0",
         "mezzio/mezzio-laminasrouter": "^3.0",
         "mockery/mockery": "^1.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "laminas/laminas-httphandlerrunner": "^1.3.0",
         "laminas/laminas-stratigility": "^3.3.0",
         "laminas/laminas-zendframework-bridge": "^1.1.0",
-        "mezzio/mezzio-router": "^3.0",
+        "mezzio/mezzio-router": "^3.2.0",
         "mezzio/mezzio-template": "^2.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "require-dev": {
         "filp/whoops": "^2.8.0",
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-diactoros": "^1.7.1 || ^2.0",
+        "laminas/laminas-diactoros": "^2.5.0",
         "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
         "malukenho/docheader": "^0.1.6",
         "mezzio/mezzio-aurarouter": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3||~8.0.0",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^1.3.0",
         "laminas/laminas-stratigility": "^3.3.0",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require": {
         "php": "^7.3",
-        "fig/http-message-util": "^1.1.2",
+        "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^1.0.1",
         "laminas/laminas-stratigility": "^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^1.3.0",
         "laminas/laminas-stratigility": "^3.3.0",
-        "laminas/laminas-zendframework-bridge": "^1.0",
+        "laminas/laminas-zendframework-bridge": "^1.1.0",
         "mezzio/mezzio-router": "^3.0",
         "mezzio/mezzio-template": "^2.0",
         "psr/container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php": "^7.3",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^1.3.0",
-        "laminas/laminas-stratigility": "^3.0",
+        "laminas/laminas-stratigility": "^3.3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.0",
         "mezzio/mezzio-template": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.3",
         "fig/http-message-util": "^1.1.5",
-        "laminas/laminas-httphandlerrunner": "^1.0.1",
+        "laminas/laminas-httphandlerrunner": "^1.3.0",
         "laminas/laminas-stratigility": "^3.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "filp/whoops": "^1.1.10 || ^2.1.13",
+        "filp/whoops": "^2.8.0",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^1.7.1 || ^2.0",
         "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^2.5.0",
         "laminas/laminas-servicemanager": "^3.6.0",
-        "malukenho/docheader": "^0.1.6",
+        "malukenho/docheader": "^0.1.8",
         "mezzio/mezzio-aurarouter": "^3.0",
         "mezzio/mezzio-fastroute": "^3.0",
         "mezzio/mezzio-laminasrouter": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^0.12.33",
         "phpstan/phpstan-phpunit": "^0.12.13",
-        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan-strict-rules": "^0.12.4",
         "phpunit/phpunit": "^9.3"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "mockery/mockery": "^1.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^0.12.33",
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan-phpunit": "^0.12.13",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "malukenho/docheader": "^0.1.8",
         "mezzio/mezzio-aurarouter": "^3.0",
         "mezzio/mezzio-fastroute": "^3.1.0",
-        "mezzio/mezzio-laminasrouter": "^3.0",
+        "mezzio/mezzio-laminasrouter": "^3.1.0",
         "mockery/mockery": "^1.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "filp/whoops": "^2.8.0",
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^2.5.0",
-        "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
+        "laminas/laminas-servicemanager": "^3.6.0",
         "malukenho/docheader": "^0.1.6",
         "mezzio/mezzio-aurarouter": "^3.0",
         "mezzio/mezzio-fastroute": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "mezzio/mezzio-laminasrouter": "^3.1.0",
         "mockery/mockery": "^1.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^0.12.33",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^9.3"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -106,11 +106,6 @@ parameters:
 			path: src/Container/WhoopsFactory.php
 
 		-
-			message: "#^Call to function method_exists\\(\\) with 'Whoops\\\\\\\\Util\\\\\\\\Misc' and 'isAjaxRequest' will always evaluate to true\\.$#"
-			count: 1
-			path: src/Container/WhoopsFactory.php
-
-		-
 			message: "#^Method Mezzio\\\\Container\\\\WhoopsPageHandlerFactory\\:\\:injectEditor\\(\\) has parameter \\$config with generic interface ArrayAccess but does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/Container/WhoopsPageHandlerFactory.php
@@ -167,11 +162,6 @@ parameters:
 
 		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
-			count: 1
-			path: src/Middleware/WhoopsErrorResponseGenerator.php
-
-		-
-			message: "#^Call to function method_exists\\(\\) with Whoops\\\\Handler\\\\JsonResponseHandler and 'contentType' will always evaluate to true\\.$#"
 			count: 1
 			path: src/Middleware/WhoopsErrorResponseGenerator.php
 

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -15,8 +15,6 @@ use Whoops\Handler\JsonResponseHandler;
 use Whoops\Run as Whoops;
 use Whoops\Util\Misc as WhoopsUtil;
 
-use function method_exists;
-
 /**
  * Create and return an instance of the Whoops runner.
  *
@@ -81,15 +79,9 @@ class WhoopsFactory
         }
 
         if (! empty($config['json_exceptions']['ajax_only'])) {
-            if (method_exists(WhoopsUtil::class, 'isAjaxRequest')) {
-                // Whoops 2.x; don't push handler on stack unless we are in
-                // an XHR request.
-                if (! WhoopsUtil::isAjaxRequest()) {
-                    return;
-                }
-            } elseif (method_exists($handler, 'onlyForAjaxRequests')) {
-                // Whoops 1.x
-                $handler->onlyForAjaxRequests(true);
+            // Don't push handler on stack unless we are in a XHR request.
+            if (! WhoopsUtil::isAjaxRequest()) {
+                return;
             }
         }
 

--- a/src/Middleware/WhoopsErrorResponseGenerator.php
+++ b/src/Middleware/WhoopsErrorResponseGenerator.php
@@ -23,7 +23,6 @@ use Whoops\RunInterface;
 use function get_class;
 use function gettype;
 use function is_object;
-use function method_exists;
 use function sprintf;
 
 class WhoopsErrorResponseGenerator
@@ -67,12 +66,7 @@ class WhoopsErrorResponseGenerator
 
             // Set Json content type header
             if ($handler instanceof JsonResponseHandler) {
-                $contentType = 'application/json';
-
-                // Whoops < 2.1.5 does not provide contentType method
-                if (method_exists($handler, 'contentType')) {
-                    $contentType = $handler->contentType();
-                }
+                $contentType = $handler->contentType();
 
                 $response = $response->withHeader('Content-Type', $contentType);
             }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This pull requests aims to make Mezzio PHP 8.0 compatible. I've bumped the dependencies to the **lowest** version that supports PHP 7.3 up until 8.0.
