### PR TITLE
Removed the "--ignore-platform-reqs" flag from Travis for the PHP 8.0 builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,9 @@ matrix:
     - php: 8.0
       env:
         - DEPS=lowest
-        - COMPOSER_ARGS=--ignore-platform-reqs
     - php: 8.0
       env:
         - DEPS=latest
-        - COMPOSER_ARGS=--ignore-platform-reqs
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Removed the "--ignore-platform-reqs" flag from Travis for the PHP 8.0 builds.