### PR TITLE
Prefer `aliases`/`decorators` over dedicated factories when searching for the `PSR-17` response factory

### DIFF
--- a/src/Container/NotFoundHandlerFactory.php
+++ b/src/Container/NotFoundHandlerFactory.php
@@ -35,10 +35,7 @@ class NotFoundHandlerFactory
             ? (string) $errorHandlerConfig['layout']
             : NotFoundHandler::LAYOUT_DEFAULT;
 
-        $dependencies = $config['dependencies'] ?? [];
-        Assert::isMap($dependencies);
-
-        $responseFactory = $this->detectResponseFactory($container, $dependencies);
+        $responseFactory = $this->detectResponseFactory($container);
 
         return new NotFoundHandler(
             $responseFactory,

--- a/src/Container/Psr17ResponseFactoryTrait.php
+++ b/src/Container/Psr17ResponseFactoryTrait.php
@@ -15,10 +15,7 @@ use Webmozart\Assert\Assert;
  */
 trait Psr17ResponseFactoryTrait
 {
-    /**
-     * @param array<string,mixed> $dependencies
-     */
-    private function detectResponseFactory(ContainerInterface $container, array $dependencies): ResponseFactoryInterface
+    private function detectResponseFactory(ContainerInterface $container): ResponseFactoryInterface
     {
         $psr17FactoryAvailable = $container->has(ResponseFactoryInterface::class);
 
@@ -26,18 +23,7 @@ trait Psr17ResponseFactoryTrait
             return $this->createResponseFactoryFromDeprecatedCallable($container);
         }
 
-        /** @psalm-suppress MixedAssignment */
-        $deprecatedResponseFactory = $dependencies['factories'][ResponseInterface::class] ?? null;
-
-        if ($deprecatedResponseFactory !== ResponseFactoryFactory::class) {
-            return $this->createResponseFactoryFromDeprecatedCallable($container);
-        }
-
-        $delegators = $dependencies['delegators'] ?? [];
-        $aliases = $dependencies['aliases'] ?? [];
-        Assert::isArrayAccessible($delegators);
-        Assert::isArrayAccessible($aliases);
-        if (isset($delegators[ResponseInterface::class]) || isset($aliases[ResponseInterface::class])) {
+        if ($this->doesConfigurationProvidesDedicatedResponseFactory($container)) {
             return $this->createResponseFactoryFromDeprecatedCallable($container);
         }
 
@@ -51,6 +37,35 @@ trait Psr17ResponseFactoryTrait
     ): ResponseFactoryInterface {
         /** @var callable():ResponseInterface $responseFactory */
         $responseFactory = $container->get(ResponseInterface::class);
+
         return new CallableResponseFactoryDecorator($responseFactory);
+    }
+
+    private function doesConfigurationProvidesDedicatedResponseFactory(ContainerInterface $container): bool
+    {
+        if (! $container->has('config')) {
+            return false;
+        }
+
+        $config = $container->get('config');
+        Assert::isArrayAccessible($config);
+        $dependencies = $config['dependencies'] ?? [];
+        Assert::isMap($dependencies);
+
+        $delegators = $dependencies['delegators'] ?? [];
+        $aliases    = $dependencies['aliases'] ?? [];
+        Assert::isArrayAccessible($delegators);
+        Assert::isArrayAccessible($aliases);
+
+        if (isset($delegators[ResponseInterface::class]) || isset($aliases[ResponseInterface::class])) {
+            // Even tho, aliases could point to a different service, we assume that there is a dedicated factory
+            // available. The alias resolving is not worth it.
+            return true;
+        }
+
+        /** @psalm-suppress MixedAssignment */
+        $deprecatedResponseFactory = $dependencies['factories'][ResponseInterface::class] ?? null;
+
+        return $deprecatedResponseFactory !== null && $deprecatedResponseFactory !== ResponseFactoryFactory::class;
     }
 }

--- a/src/Container/ServerRequestErrorResponseGeneratorFactory.php
+++ b/src/Container/ServerRequestErrorResponseGeneratorFactory.php
@@ -33,10 +33,7 @@ class ServerRequestErrorResponseGeneratorFactory
         $template = $errorHandlerConfiguration['template_error']
             ?? ServerRequestErrorResponseGenerator::TEMPLATE_DEFAULT;
 
-        $dependencies = $config['dependencies'] ?? [];
-        Assert::isMap($dependencies);
-
-        $responseFactory = $this->detectResponseFactory($container, $dependencies);
+        $responseFactory = $this->detectResponseFactory($container);
 
         return new ServerRequestErrorResponseGenerator(
             $responseFactory,


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes (on trait which is marked `@internal`)

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

While working on mezzio/mezzio-router#23, I've made some changes to the trait which detects dedicated response factories provided by upstream projects.

This fix is not really urgent but it might catch some edge-cases in upstream projects.
