### PR TITLE
Build `Application` with `RequestHandlerRunnerInterface` instead of `RequestHandlerRunner`, alias `RequestHandlerRunner` as `RequestHandlerRunnerInterface`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,7 +50,7 @@
     <MixedArgument occurrences="5">
       <code>$container-&gt;get(ApplicationPipeline::class)</code>
       <code>$container-&gt;get(MiddlewareFactory::class)</code>
-      <code>$container-&gt;get(RequestHandlerRunner::class)</code>
+      <code>$container-&gt;get(RequestHandlerRunnerInterface::class)</code>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
     <UndefinedClass occurrences="1">

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,6 +6,7 @@ namespace Mezzio;
 
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
+use Laminas\HttpHandlerRunner\RequestHandlerRunnerInterface;
 use Laminas\Stratigility\Middleware\ErrorHandler;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -36,6 +37,8 @@ class ConfigProvider
                 IMPLICIT_OPTIONS_MIDDLEWARE => Router\Middleware\ImplicitOptionsMiddleware::class,
                 NOT_FOUND_MIDDLEWARE        => Handler\NotFoundHandler::class,
                 ROUTE_MIDDLEWARE            => Router\Middleware\RouteMiddleware::class,
+
+                RequestHandlerRunnerInterface::class => RequestHandlerRunner::class,
 
                 // Legacy Zend Framework aliases
                 \Zend\Expressive\Application::class => Application::class,

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Container;
 
-use Laminas\HttpHandlerRunner\RequestHandlerRunner;
+use Laminas\HttpHandlerRunner\RequestHandlerRunnerInterface;
 use Mezzio\Application;
 use Mezzio\ApplicationPipeline;
 use Mezzio\MiddlewareFactory;
@@ -34,7 +34,7 @@ class ApplicationFactory
             $container->has(RouteCollectorInterface::class) ?
                 $container->get(RouteCollectorInterface::class) :
                 $container->get(RouteCollector::class),
-            $container->get(RequestHandlerRunner::class)
+            $container->get(RequestHandlerRunnerInterface::class)
         );
     }
 }

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MezzioTest\Container;
 
-use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\HttpHandlerRunner\RequestHandlerRunnerInterface;
 use Laminas\Stratigility\MiddlewarePipeInterface;
 use Mezzio\Application;
@@ -28,7 +27,7 @@ class ApplicationFactoryTest extends TestCase
         $container->set(MiddlewareFactory::class, $middlewareFactory);
         $container->set(ApplicationPipeline::class, $pipeline);
         $container->set(RouteCollector::class, $routeCollector);
-        $container->set(RequestHandlerRunner::class, $runner);
+        $container->set(RequestHandlerRunnerInterface::class, $runner);
 
         $factory = new ApplicationFactory();
 


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

Using interface-based dependence allows us to swtich the other implementations more easily.
