### PR TITLE
Provide integration with Diactoros FilterServerRequestInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require-dev": {
         "filp/whoops": "^2.14.4",
         "laminas/laminas-coding-standard": "~2.3.0",
-        "laminas/laminas-diactoros": "^2.8.0",
+        "laminas/laminas-diactoros": "^2.11.2",
         "laminas/laminas-servicemanager": "^3.10",
         "malukenho/docheader": "^0.1.8",
         "mezzio/mezzio-aurarouter": "^3.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63b017b1e3cdbc577175602103c1af6f",
+    "content-hash": "9ff487244b235bfa7ced9d1f07a7f983",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -64,16 +64,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.8.0",
+            "version": "2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199"
+                "reference": "78846cbce0550ec174508a646f46fd6dee76099b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
-                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/78846cbce0550ec174508a646f46fd6dee76099b",
+                "reference": "78846cbce0550ec174508a646f46fd6dee76099b",
                 "shasum": ""
             },
             "require": {
@@ -159,37 +159,37 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-22T03:54:36+00:00"
+            "time": "2022-06-29T14:15:02+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f"
+                "reference": "58af67282db37d24e584a837a94ee55b9c7552be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/891ad70986729e20ed2e86355fcf93c9dc238a5f",
-                "reference": "891ad70986729e20ed2e86355fcf93c9dc238a5f",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/58af67282db37d24e584a837a94ee55b9c7552be",
+                "reference": "58af67282db37d24e584a837a94ee55b9c7552be",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "ext-ctype": "*",
+                "ext-mbstring": "*",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-escaper": "*"
             },
             "require-dev": {
+                "infection/infection": "^0.26.6",
                 "laminas/laminas-coding-standard": "~2.3.0",
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.12.2",
-                "vimeo/psalm": "^3.16"
-            },
-            "suggest": {
-                "ext-iconv": "*",
-                "ext-mbstring": "*"
+                "maglnet/composer-require-checker": "^3.8.0",
+                "phpunit/phpunit": "^9.5.18",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.22.0"
             },
             "type": "library",
             "autoload": {
@@ -221,7 +221,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-02T17:10:53+00:00"
+            "time": "2022-03-08T20:15:36+00:00"
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
@@ -789,104 +789,22 @@
             "time": "2018-10-30T17:12:04+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "provide": {
-                "ext-ctype": "*"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-10-20T20:35:02+00:00"
-        },
-        {
             "name": "webmozart/assert",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
+                "ext-ctype": "*",
+                "php": "^7.2 || ^8.0"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
@@ -924,24 +842,24 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
-            "time": "2021-03-09T10:59:23+00:00"
+            "time": "2022-06-03T18:03:27+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.1",
+            "version": "v2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae"
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
-                "reference": "c5fc66a78ee38d7ac9195a37bacaf940eb3f65ae",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
                 "shasum": ""
             },
             "require": {
@@ -994,7 +912,7 @@
                 }
             ],
             "description": "A non-blocking concurrency framework for PHP applications.",
-            "homepage": "http://amphp.org/amp",
+            "homepage": "https://amphp.org/amp",
             "keywords": [
                 "async",
                 "asynchronous",
@@ -1009,7 +927,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.1"
+                "source": "https://github.com/amphp/amp/tree/v2.6.2"
             },
             "funding": [
                 {
@@ -1017,7 +935,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-09-23T18:43:08+00:00"
+            "time": "2022-02-20T17:52:18+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -1224,30 +1142,30 @@
         },
         {
             "name": "composer/pcre",
-            "version": "1.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
-                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/e300eb6c535192decd27a85bc72a9290f0d6b3bd",
+                "reference": "e300eb6c535192decd27a85bc72a9290f0d6b3bd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.3",
                 "phpstan/phpstan-strict-rules": "^1.1",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "symfony/phpunit-bridge": "^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1275,7 +1193,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/1.0.1"
+                "source": "https://github.com/composer/pcre/tree/3.0.0"
             },
             "funding": [
                 {
@@ -1291,20 +1209,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-21T20:24:37+00:00"
+            "time": "2022-02-25T20:21:48+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.2.9",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649"
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/a951f614bd64dcd26137bc9b7b2637ddcfc57649",
-                "reference": "a951f614bd64dcd26137bc9b7b2637ddcfc57649",
+                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
                 "shasum": ""
             },
             "require": {
@@ -1356,7 +1274,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.2.9"
+                "source": "https://github.com/composer/semver/tree/3.3.2"
             },
             "funding": [
                 {
@@ -1372,24 +1290,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-04T13:58:43+00:00"
+            "time": "2022-04-01T19:23:25+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "3.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8"
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/12f1b79476638a5615ed00ea6adbb269cec96fd8",
-                "reference": "12f1b79476638a5615ed00ea6adbb269cec96fd8",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
                 "shasum": ""
             },
             "require": {
-                "composer/pcre": "^1",
+                "composer/pcre": "^1 || ^2 || ^3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1 || ^2 || ^3"
             },
@@ -1422,7 +1340,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/xdebug-handler/issues",
-                "source": "https://github.com/composer/xdebug-handler/tree/3.0.1"
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
             },
             "funding": [
                 {
@@ -1438,43 +1356,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T18:29:42+00:00"
-        },
-        {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
+            "time": "2022-02-25T21:32:43+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -1590,29 +1472,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -1639,7 +1522,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
             },
             "funding": [
                 {
@@ -1655,7 +1538,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1704,16 +1587,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "1.5.1",
+            "version": "v1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
-                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
                 "shasum": ""
             },
             "require": {
@@ -1754,9 +1637,9 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
             },
-            "time": "2021-02-22T14:02:09+00:00"
+            "time": "2022-03-02T22:36:06+00:00"
         },
         {
             "name": "filp/whoops",
@@ -2192,44 +2075,46 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.10.0",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
+                "reference": "6f96556ee314f9e0d57d83967c0087332836c31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
-                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/6f96556ee314f9e0d57d83967c0087332836c31d",
+                "reference": "6f96556ee314f9e0d57d83967c0087332836c31d",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
+                "ext-psr": "*",
                 "laminas/laminas-code": "<3.3.1",
                 "zendframework/zend-code": "<3.3.1",
                 "zendframework/zend-servicemanager": "*"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.1",
-                "laminas/laminas-container-config-test": "^0.3",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
                 "laminas/laminas-dependency-plugin": "^2.1.2",
                 "mikey179/vfsstream": "^1.6.10@alpha",
                 "ocramius/proxy-manager": "^2.11",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.8"
             },
             "suggest": {
@@ -2241,6 +2126,9 @@
             ],
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -2274,20 +2162,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-18T20:19:36+00:00"
+            "time": "2022-06-29T08:01:37+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.7.1",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325"
+                "reference": "0d669074845fc80a99add0f64025192f143ef836"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/bcd869e2fe88d567800057c1434f2380354fe325",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/0d669074845fc80a99add0f64025192f143ef836",
+                "reference": "0d669074845fc80a99add0f64025192f143ef836",
                 "shasum": ""
             },
             "require": {
@@ -2333,7 +2221,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-21T15:50:46+00:00"
+            "time": "2022-06-10T14:49:09+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -2395,22 +2283,22 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.16.0",
+            "version": "2.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "329900ab7674c198e91e85b2e09080cdf493ce07"
+                "reference": "ba665f5a52763dda5a747c4ad826d2adf1510486"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/329900ab7674c198e91e85b2e09080cdf493ce07",
-                "reference": "329900ab7674c198e91e85b2e09080cdf493ce07",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ba665f5a52763dda5a747c4ad826d2adf1510486",
+                "reference": "ba665f5a52763dda5a747c4ad826d2adf1510486",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.1",
-                "laminas/laminas-stdlib": "^3.6",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "laminas/laminas-servicemanager": "^3.12.0",
+                "laminas/laminas-stdlib": "^3.10",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
                 "zendframework/zend-validator": "*"
@@ -2419,27 +2307,24 @@
                 "laminas/laminas-cache": "^2.6.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-db": "^2.7",
-                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-filter": "^2.14.0",
                 "laminas/laminas-http": "^2.14.2",
-                "laminas/laminas-i18n": "^2.6",
-                "laminas/laminas-math": "^2.6",
-                "laminas/laminas-servicemanager": "^2.7.11 || ^3.0.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-uri": "^2.7",
+                "laminas/laminas-i18n": "^2.15.0",
+                "laminas/laminas-session": "^2.12.1",
+                "laminas/laminas-uri": "^2.9.1",
                 "phpspec/prophecy-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5.5",
                 "psalm/plugin-phpunit": "^0.15.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0",
-                "vimeo/psalm": "^4.3"
+                "vimeo/psalm": "^4.23"
             },
             "suggest": {
                 "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
                 "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
                 "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
                 "laminas/laminas-i18n-resources": "Translations of validator messages",
-                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
                 "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
                 "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
                 "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
@@ -2481,7 +2366,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-21T14:30:01+00:00"
+            "time": "2022-06-14T12:31:18+00:00"
         },
         {
             "name": "malukenho/docheader",
@@ -2838,25 +2723,29 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+            },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
@@ -2881,7 +2770,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
             },
             "funding": [
                 {
@@ -2889,7 +2778,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -2994,16 +2883,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.2",
+            "version": "v4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
                 "shasum": ""
             },
             "require": {
@@ -3044,9 +2933,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.14.0"
             },
-            "time": "2021-11-30T19:35:32+00:00"
+            "time": "2022-05-31T20:59:12+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -3163,16 +3052,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.1.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
@@ -3208,9 +3097,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
-            "time": "2021-02-23T14:00:09+00:00"
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3324,16 +3213,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -3368,9 +3257,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2022-01-04T19:58:01+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3441,35 +3330,31 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.2.0",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
-                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/135607f9ccc297d6923d49c2bcf309f509413215",
+                "reference": "135607f9ccc297d6923d49c2bcf309f509413215",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PHPStan\\PhpDocParser\\": [
@@ -3484,22 +3369,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.6.4"
             },
-            "time": "2021-09-16T20:46:02+00:00"
+            "time": "2022-06-26T13:09:08+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.10",
+            "version": "9.2.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
@@ -3555,7 +3440,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
             },
             "funding": [
                 {
@@ -3563,7 +3448,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-05T09:12:13+00:00"
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3808,16 +3693,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.13",
+            "version": "9.5.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
-                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e32b76be457de00e83213528f6bb37e2a38fcb1",
+                "reference": "0e32b76be457de00e83213528f6bb37e2a38fcb1",
                 "shasum": ""
             },
             "require": {
@@ -3833,7 +3718,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-code-coverage": "^9.2.13",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -3847,11 +3732,10 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
+                "sebastian/type": "^3.0",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*",
                 "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
@@ -3895,7 +3779,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.21"
             },
             "funding": [
                 {
@@ -3907,7 +3791,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-24T07:33:35+00:00"
+            "time": "2022-06-19T12:14:25+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4381,16 +4265,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.3",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
                 "shasum": ""
             },
             "require": {
@@ -4432,7 +4316,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
             },
             "funding": [
                 {
@@ -4440,7 +4324,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:52:38+00:00"
+            "time": "2022-04-03T09:37:03+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4521,16 +4405,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.3",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
@@ -4573,7 +4457,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -4581,7 +4465,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-11T13:31:12+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -4872,28 +4756,28 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4916,7 +4800,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
             },
             "funding": [
                 {
@@ -4924,7 +4808,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-06-15T12:49:02+00:00"
+            "time": "2022-03-15T09:54:48+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4981,32 +4865,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.0.18",
+            "version": "7.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc"
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
-                "reference": "b81ac84f41a4797dc25c8ede1b0718e2a74be0fc",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.0.0",
-                "squizlabs/php_codesniffer": "^3.6.1"
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phing/phing": "2.17.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.1",
-                "phpstan/phpstan": "1.2.0",
+                "phing/phing": "2.17.3",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.7.1",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
-                "phpstan/phpstan-phpunit": "1.0.0",
-                "phpstan/phpstan-strict-rules": "1.1.0",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.10"
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5026,7 +4910,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.0.18"
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
             },
             "funding": [
                 {
@@ -5038,20 +4922,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-07T17:19:06+00:00"
+            "time": "2022-05-25T10:58:12+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.2",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
-                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -5094,20 +4978,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-12-12T21:44:58+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.3",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a2a86ec353d825c75856c6fd14fac416a7bdb6b8"
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a2a86ec353d825c75856c6fd14fac416a7bdb6b8",
-                "reference": "a2a86ec353d825c75856c6fd14fac416a7bdb6b8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4d671ab4ddac94ee439ea73649c69d9d200b5000",
+                "reference": "4d671ab4ddac94ee439ea73649c69d9d200b5000",
                 "shasum": ""
             },
             "require": {
@@ -5177,7 +5061,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.3"
+                "source": "https://github.com/symfony/console/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -5193,20 +5077,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-26T16:28:35+00:00"
+            "time": "2022-06-26T13:00:04+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
-                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
                 "shasum": ""
             },
             "require": {
@@ -5244,7 +5128,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -5260,20 +5144,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-07-12T14:48:14+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.3",
+            "version": "v5.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d"
+                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/231313534dded84c7ecaa79d14bc5da4ccb69b7d",
-                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/9b630f3427f3ebe7cd346c277a1408b00249dad9",
+                "reference": "9b630f3427f3ebe7cd346c277a1408b00249dad9",
                 "shasum": ""
             },
             "require": {
@@ -5307,7 +5191,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.3"
+                "source": "https://github.com/symfony/finder/tree/v5.4.8"
             },
             "funding": [
                 {
@@ -5323,20 +5207,102 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-26T16:34:36+00:00"
+            "time": "2022-04-15T08:07:45+00:00"
         },
         {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.24.0",
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783"
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/81b86b50cf841a64252b439e738e97f4a34e2783",
-                "reference": "81b86b50cf841a64252b439e738e97f4a34e2783",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.26-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.26.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/433d05519ce6990bf3530fba6957499d327395c2",
+                "reference": "433d05519ce6990bf3530fba6957499d327395c2",
                 "shasum": ""
             },
             "require": {
@@ -5348,7 +5314,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5388,7 +5354,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5404,20 +5370,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T21:10:46+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.24.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
-                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/219aa369ceff116e673852dce47c3a41794c14bd",
+                "reference": "219aa369ceff116e673852dce47c3a41794c14bd",
                 "shasum": ""
             },
             "require": {
@@ -5429,7 +5395,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5472,7 +5438,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5488,20 +5454,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.24.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
@@ -5516,7 +5482,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5555,7 +5521,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5571,20 +5537,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-30T18:21:41+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.24.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5"
+                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/cc5db0e22b3cb4111010e48785a97f670b350ca5",
-                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/e440d35fa0286f77fb45b79a03fedbeda9307e85",
+                "reference": "e440d35fa0286f77fb45b79a03fedbeda9307e85",
                 "shasum": ""
             },
             "require": {
@@ -5593,7 +5559,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5634,7 +5600,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5650,20 +5616,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-06-05T21:20:04+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.24.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9"
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/57b712b08eddb97c762a8caa32c84e037892d2e9",
-                "reference": "57b712b08eddb97c762a8caa32c84e037892d2e9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
                 "shasum": ""
             },
             "require": {
@@ -5672,7 +5638,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -5717,7 +5683,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -5733,26 +5699,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T13:58:33+00:00"
+            "time": "2022-05-10T07:21:04+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.0",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
-                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "psr/container": "^1.1",
-                "symfony/deprecation-contracts": "^2.1"
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -5800,7 +5766,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -5816,20 +5782,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-04T16:48:04+00:00"
+            "time": "2022-05-30T19:17:29+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.3",
+            "version": "v5.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10"
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/92043b7d8383e48104e411bc9434b260dbeb5a10",
-                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10",
+                "url": "https://api.github.com/repos/symfony/string/zipball/4432bc7df82a554b3e413a8570ce2fea90e94097",
+                "reference": "4432bc7df82a554b3e413a8570ce2fea90e94097",
                 "shasum": ""
             },
             "require": {
@@ -5851,12 +5817,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
                 "files": [
                     "Resources/functions.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
                 "exclude-from-classmap": [
                     "/Tests/"
                 ]
@@ -5886,7 +5852,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.3"
+                "source": "https://github.com/symfony/string/tree/v5.4.10"
             },
             "funding": [
                 {
@@ -5902,7 +5868,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2022-06-26T15:57:47+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5956,16 +5922,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.20.0",
+            "version": "4.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f82a70e7edfc6cf2705e9374c8a0b6a974a779ed"
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f82a70e7edfc6cf2705e9374c8a0b6a974a779ed",
-                "reference": "f82a70e7edfc6cf2705e9374c8a0b6a974a779ed",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/06dd975cb55d36af80f242561738f16c5f58264f",
+                "reference": "06dd975cb55d36af80f242561738f16c5f58264f",
                 "shasum": ""
             },
             "require": {
@@ -5990,6 +5956,7 @@
                 "php": "^7.1|^8",
                 "sebastian/diff": "^3.0 || ^4.0",
                 "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+                "symfony/polyfill-php80": "^1.25",
                 "webmozart/path-util": "^2.3"
             },
             "provide": {
@@ -6056,30 +6023,30 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.20.0"
+                "source": "https://github.com/vimeo/psalm/tree/4.24.0"
             },
-            "time": "2022-02-03T17:03:47+00:00"
+            "time": "2022-06-26T11:47:54+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74"
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/7a71421c7fc85827488f10c4c510fe80f94d1a74",
-                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.1"
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.10"
+                "phpunit/phpunit": "^9.5.13"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -6105,7 +6072,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.3"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
             },
             "funding": [
                 {
@@ -6113,7 +6080,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-10-28T21:18:17+00:00"
+            "time": "2022-02-15T19:52:12+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -257,11 +257,11 @@ Also by default, this factory will consume the service `Laminas\Diactoros\Server
 
 If you want to limit the proxy servers you trust (or supply one or more subnets), or which `X-Forwarded-*` headers are trusted, you should define the `Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface` service; one option is to use the shipped [FilterUsingXForwardedHeadersFactory described below](#filterusingxforwardedheadersfactory).
 
-Alternately, if you want to disable usage of proxy headers entirely, alias the `FilterServerRequestInterface` to the `Laminas\Diactoros\ServerRequestFilter\DoNotFilter` class:
+Alternately, if you want to disable usage of proxy headers entirely, alias the `FilterServerRequestInterface` as an invokable to the `Laminas\Diactoros\ServerRequestFilter\DoNotFilter` class:
 
 ```php
 'dependencies' => [
-    'aliases' => [
+    'invokables' => [
         Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface::class => 
             Laminas\Diactoros\ServerRequestFilter\DoNotFilter::class,
     ],

--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -537,8 +537,8 @@ $config = [
     'laminas-diactoros' => [
         'server-request-filter' => [
             'x-forwarded-headers' => [
-                'trusted-proxies' => string|string[],
-                'trusted-headers' => string[],
+                'trusted-proxies' => list<string>,
+                'trusted-headers' => list<string>,
             ],
         ],
     ],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.13.1@5cf660f63b548ccd4a56f62d916ee4d6028e01a3">
+<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
   <file src="src/Application.php">
     <PossiblyInvalidCast occurrences="1">
       <code>$path</code>
     </PossiblyInvalidCast>
   </file>
   <file src="src/ConfigProvider.php">
-    <MixedArrayOffset occurrences="2"/>
-    <UndefinedClass occurrences="3">
+    <MixedArrayOffset occurrences="1"/>
+    <UndefinedClass occurrences="2">
       <code>ApplicationPipeline</code>
       <code>ApplicationPipeline</code>
-      <code>\Zend\Expressive\ApplicationPipeline</code>
     </UndefinedClass>
   </file>
   <file src="src/Container/ApplicationConfigInjectionDelegator.php">
@@ -32,11 +31,10 @@
       <code>$spec['middleware']</code>
       <code>$spec['path']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="8">
+    <MixedAssignment occurrences="7">
       <code>$config</code>
       <code>$methods</code>
       <code>$name</code>
-      <code>$options</code>
       <code>$path</code>
       <code>$queue</code>
       <code>$serial</code>
@@ -83,6 +81,19 @@
       <code>$template</code>
     </MixedAssignment>
   </file>
+  <file src="src/Container/FilterUsingXForwardedHeadersFactory.php">
+    <MixedArgumentTypeCoercion occurrences="3">
+      <code>$headers</code>
+      <code>$proxies</code>
+      <code>$proxies</code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess occurrences="1">
+      <code>$config[ConfigProvider::DIACTOROS_CONFIG_KEY]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$config</code>
+    </MixedAssignment>
+  </file>
   <file src="src/Container/MiddlewareFactoryFactory.php">
     <MixedArgument occurrences="1">
       <code>$container-&gt;get(MiddlewareContainer::class)</code>
@@ -125,6 +136,14 @@
       <code>$debug</code>
       <code>$renderer</code>
       <code>$template</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/Container/ServerRequestFactoryFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$filter</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$filter</code>
     </MixedAssignment>
   </file>
   <file src="src/Container/WhoopsErrorResponseGeneratorFactory.php">
@@ -279,7 +298,8 @@
       <code>$json['packages']</code>
       <code>$package['extra']</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="1">
+    <MixedArrayAssignment occurrences="2">
+      <code>$config['dependencies']['services']</code>
       <code>$config['dependencies']['services']</code>
     </MixedArrayAssignment>
     <MixedAssignment occurrences="8">
@@ -303,10 +323,6 @@
     </UndefinedClass>
   </file>
   <file src="test/Container/ApplicationConfigInjectionDelegatorTest.php">
-    <MissingClosureParamType occurrences="2">
-      <code>$found</code>
-      <code>$route</code>
-    </MissingClosureParamType>
     <MixedArgument occurrences="1">
       <code>$pipeline</code>
     </MixedArgument>
@@ -336,15 +352,22 @@
       <code>ApplicationPipeline</code>
     </UndefinedClass>
   </file>
-  <file src="test/Container/EmitterFactoryTest.php">
-    <MixedAssignment occurrences="1">
-      <code>$emitter</code>
-    </MixedAssignment>
-  </file>
   <file src="test/Container/ErrorHandlerFactoryTest.php">
     <InvalidArgument occurrences="1">
       <code>$generator</code>
     </InvalidArgument>
+  </file>
+  <file src="test/Container/FilterUsingXForwardedHeadersFactoryTest.php">
+    <MoreSpecificReturnType occurrences="1">
+      <code>iterable&lt;string, array{0: string, 1: array&lt;string, string&gt;}&gt;</code>
+    </MoreSpecificReturnType>
+    <UndefinedInterfaceMethod occurrences="5">
+      <code>set</code>
+      <code>set</code>
+      <code>set</code>
+      <code>set</code>
+      <code>set</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="test/Container/NotFoundHandlerFactoryTest.php">
     <MixedArgument occurrences="4">
@@ -461,9 +484,6 @@
     </PossiblyFalseOperand>
   </file>
   <file src="test/Middleware/ErrorResponseGeneratorTest.php">
-    <MissingClosureParamType occurrences="1">
-      <code>$body</code>
-    </MissingClosureParamType>
     <MixedArgument occurrences="1">
       <code>$body</code>
     </MixedArgument>
@@ -560,9 +580,6 @@
     <MixedReturnStatement occurrences="1">
       <code>$res-&gt;withBody($stream)</code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>testMatchWithAllHttpMethods</code>
-    </PossiblyInvalidArgument>
     <UnusedClosureParam occurrences="18">
       <code>$handler</code>
       <code>$handler</code>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="1"
     errorBaseline="psalm-baseline.xml">
     <projectFiles>
         <directory name="bin"/>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio;
 
-use Laminas\Diactoros\ConfigProvider as DiactorosConfigProvider;
-use Laminas\Diactoros\ServerRequestFilter\ServerRequestFilterInterface;
-use Laminas\Diactoros\ServerRequestFilter\XForwardedHeaderFilterFactory;
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\HttpHandlerRunner\RequestHandlerRunnerInterface;
@@ -14,6 +11,9 @@ use Laminas\Stratigility\Middleware\ErrorHandler;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Zend\Expressive\Handler\NotFoundHandler;
+use Zend\Expressive\Middleware\ErrorResponseGenerator;
+use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 
 /**
  * Provide initial configuration for mezzio.
@@ -22,72 +22,61 @@ use Psr\Http\Message\StreamInterface;
  */
 class ConfigProvider
 {
+    public const DIACTOROS_CONFIG_KEY                       = 'laminas-diactoros';
+    public const DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY = 'server-request-filter';
+    public const DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY    = 'x-forwarded-headers';
+    public const DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY       = 'trusted-proxies';
+    public const DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY       = 'trusted-headers';
+
     public function __invoke(): array
     {
         return [
-            'dependencies'                      => $this->getDependencies(),
-            // @todo Remove this for version 4
-            DiactorosConfigProvider::CONFIG_KEY => $this->getDefaultServerRequestFilterConfig(),
+            'dependencies' => $this->getDependencies(),
         ];
     }
 
     public function getDependencies(): array
     {
-        // @codingStandardsIgnoreStart
+        // phpcs:disable Generic.Files.LineLength.TooLong
         return [
-            'aliases' => [
-                DEFAULT_DELEGATE            => Handler\NotFoundHandler::class,
-                DISPATCH_MIDDLEWARE         => Router\Middleware\DispatchMiddleware::class,
-                IMPLICIT_HEAD_MIDDLEWARE    => Router\Middleware\ImplicitHeadMiddleware::class,
-                IMPLICIT_OPTIONS_MIDDLEWARE => Router\Middleware\ImplicitOptionsMiddleware::class,
-                NOT_FOUND_MIDDLEWARE        => Handler\NotFoundHandler::class,
-                ROUTE_MIDDLEWARE            => Router\Middleware\RouteMiddleware::class,
-
+            'aliases'   => [
+                DEFAULT_DELEGATE                     => Handler\NotFoundHandler::class,
+                DISPATCH_MIDDLEWARE                  => Router\Middleware\DispatchMiddleware::class,
+                IMPLICIT_HEAD_MIDDLEWARE             => Router\Middleware\ImplicitHeadMiddleware::class,
+                IMPLICIT_OPTIONS_MIDDLEWARE          => Router\Middleware\ImplicitOptionsMiddleware::class,
+                NOT_FOUND_MIDDLEWARE                 => Handler\NotFoundHandler::class,
+                ROUTE_MIDDLEWARE                     => Router\Middleware\RouteMiddleware::class,
                 RequestHandlerRunnerInterface::class => RequestHandlerRunner::class,
 
                 // Legacy Zend Framework aliases
-                \Zend\Expressive\Application::class => Application::class,
-                \Zend\Expressive\ApplicationPipeline::class => ApplicationPipeline::class,
+                \Zend\Expressive\Application::class                     => Application::class,
+                \Zend\Expressive\ApplicationPipeline::class             => ApplicationPipeline::class,
                 \Zend\HttpHandlerRunner\Emitter\EmitterInterface::class => EmitterInterface::class,
-                \Zend\Stratigility\Middleware\ErrorHandler::class => ErrorHandler::class,
-                \Zend\Expressive\Handler\NotFoundHandler::class => Handler\NotFoundHandler::class,
-                \Zend\Expressive\MiddlewareContainer::class => MiddlewareContainer::class,
-                \Zend\Expressive\MiddlewareFactory::class => MiddlewareFactory::class,
-                \Zend\Expressive\Middleware\ErrorResponseGenerator::class => Middleware\ErrorResponseGenerator::class,
-                \Zend\HttpHandlerRunner\RequestHandlerRunner::class => RequestHandlerRunner::class,
-                \Zend\Expressive\Response\ServerRequestErrorResponseGenerator::class => Response\ServerRequestErrorResponseGenerator::class,
+                \Zend\Stratigility\Middleware\ErrorHandler::class       => ErrorHandler::class,
+                NotFoundHandler::class                                  => Handler\NotFoundHandler::class,
+                \Zend\Expressive\MiddlewareContainer::class             => MiddlewareContainer::class,
+                \Zend\Expressive\MiddlewareFactory::class               => MiddlewareFactory::class,
+                ErrorResponseGenerator::class                           => Middleware\ErrorResponseGenerator::class,
+                \Zend\HttpHandlerRunner\RequestHandlerRunner::class     => RequestHandlerRunner::class,
+                ServerRequestErrorResponseGenerator::class              => Response\ServerRequestErrorResponseGenerator::class,
             ],
             'factories' => [
-                Application::class                       => Container\ApplicationFactory::class,
-                ApplicationPipeline::class               => Container\ApplicationPipelineFactory::class,
-                EmitterInterface::class                  => Container\EmitterFactory::class,
-                ErrorHandler::class                      => Container\ErrorHandlerFactory::class,
-                Handler\NotFoundHandler::class           => Container\NotFoundHandlerFactory::class,
-                MiddlewareContainer::class               => Container\MiddlewareContainerFactory::class,
-                MiddlewareFactory::class                 => Container\MiddlewareFactoryFactory::class,
+                Application::class             => Container\ApplicationFactory::class,
+                ApplicationPipeline::class     => Container\ApplicationPipelineFactory::class,
+                EmitterInterface::class        => Container\EmitterFactory::class,
+                ErrorHandler::class            => Container\ErrorHandlerFactory::class,
+                Handler\NotFoundHandler::class => Container\NotFoundHandlerFactory::class,
+                MiddlewareContainer::class     => Container\MiddlewareContainerFactory::class,
+                MiddlewareFactory::class       => Container\MiddlewareFactoryFactory::class,
                 // Change the following in development to the WhoopsErrorResponseGeneratorFactory:
-                Middleware\ErrorResponseGenerator::class => Container\ErrorResponseGeneratorFactory::class,
-                RequestHandlerRunner::class              => Container\RequestHandlerRunnerFactory::class,
-                ResponseInterface::class                 => Container\ResponseFactoryFactory::class,
-                Response\ServerRequestErrorResponseGenerator::class  => Container\ServerRequestErrorResponseGeneratorFactory::class,
-                // @todo Switch this to the NoOpRequestFilterFactory for version 4
-                ServerRequestFilterInterface::class      => XForwardedHeaderFilterFactory::class,
-                ServerRequestInterface::class            => Container\ServerRequestFactoryFactory::class,
-                StreamInterface::class                   => Container\StreamFactoryFactory::class,
+                Middleware\ErrorResponseGenerator::class            => Container\ErrorResponseGeneratorFactory::class,
+                RequestHandlerRunner::class                         => Container\RequestHandlerRunnerFactory::class,
+                ResponseInterface::class                            => Container\ResponseFactoryFactory::class,
+                Response\ServerRequestErrorResponseGenerator::class => Container\ServerRequestErrorResponseGeneratorFactory::class,
+                ServerRequestInterface::class                       => Container\ServerRequestFactoryFactory::class,
+                StreamInterface::class                              => Container\StreamFactoryFactory::class,
             ],
         ];
-        // @codingStandardsIgnoreEnd
-    }
-
-    /**
-     * @todo Remove this for version 4.
-     */
-    public function getDefaultServerRequestFilterConfig(): array
-    {
-        return [
-            DiactorosConfigProvider::X_FORWARDED => [
-                DiactorosConfigProvider::X_FORWARDED_TRUST_ANY => true,
-            ],
-        ];
+        // phpcs:enable Generic.Files.LineLength.TooLong
     }
 }

--- a/src/Container/Exception/InvalidTrustedHeaderConfigurationException.php
+++ b/src/Container/Exception/InvalidTrustedHeaderConfigurationException.php
@@ -7,12 +7,18 @@ namespace Mezzio\Container\Exception;
 use Mezzio\ConfigProvider;
 use Mezzio\Exception\RuntimeException;
 
+use function get_class;
+use function gettype;
+use function is_object;
 use function sprintf;
 
 class InvalidTrustedHeaderConfigurationException extends RuntimeException implements ExceptionInterface
 {
-    public static function forType(string $type): self
+    /** @param mixed $headers */
+    public static function forHeaders($headers): self
     {
+        $type = is_object($headers) ? get_class($headers) : gettype($headers);
+
         return new self(sprintf(
             'Invalid %s.%s.%s.%s configuration; received %s; should be list<string>',
             ConfigProvider::DIACTOROS_CONFIG_KEY,

--- a/src/Container/Exception/InvalidTrustedHeaderConfigurationException.php
+++ b/src/Container/Exception/InvalidTrustedHeaderConfigurationException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Container\Exception;
+
+use Mezzio\ConfigProvider;
+use Mezzio\Exception\RuntimeException;
+
+use function sprintf;
+
+class InvalidTrustedHeaderConfigurationException extends RuntimeException implements ExceptionInterface
+{
+    public static function forType(string $type): self
+    {
+        return new self(sprintf(
+            'Invalid %s.%s.%s.%s configuration; received %s; should be list<string>',
+            ConfigProvider::DIACTOROS_CONFIG_KEY,
+            ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY,
+            ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY,
+            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY,
+            $type,
+        ));
+    }
+}

--- a/src/Container/Exception/InvalidTrustedProxyConfigurationException.php
+++ b/src/Container/Exception/InvalidTrustedProxyConfigurationException.php
@@ -7,12 +7,18 @@ namespace Mezzio\Container\Exception;
 use Mezzio\ConfigProvider;
 use Mezzio\Exception\RuntimeException;
 
+use function get_class;
+use function gettype;
+use function is_object;
 use function sprintf;
 
 class InvalidTrustedProxyConfigurationException extends RuntimeException implements ExceptionInterface
 {
-    public static function forType(string $type): self
+    /** @param mixed $proxies */
+    public static function forProxies($proxies): self
     {
+        $type = is_object($proxies) ? get_class($proxies) : gettype($proxies);
+
         return new self(sprintf(
             'Invalid %s.%s.%s.%s configuration; received %s; should be list<string>',
             ConfigProvider::DIACTOROS_CONFIG_KEY,

--- a/src/Container/Exception/InvalidTrustedProxyConfigurationException.php
+++ b/src/Container/Exception/InvalidTrustedProxyConfigurationException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Container\Exception;
+
+use Mezzio\ConfigProvider;
+use Mezzio\Exception\RuntimeException;
+
+use function sprintf;
+
+class InvalidTrustedProxyConfigurationException extends RuntimeException implements ExceptionInterface
+{
+    public static function forType(string $type): self
+    {
+        return new self(sprintf(
+            'Invalid %s.%s.%s.%s configuration; received %s; should be list<string>',
+            ConfigProvider::DIACTOROS_CONFIG_KEY,
+            ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY,
+            ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY,
+            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY,
+            $type,
+        ));
+    }
+}

--- a/src/Container/FilterUsingXForwardedHeadersFactory.php
+++ b/src/Container/FilterUsingXForwardedHeadersFactory.php
@@ -8,10 +8,7 @@ use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
 use Mezzio\ConfigProvider;
 use Psr\Container\ContainerInterface;
 
-use function get_class;
-use function gettype;
 use function is_array;
-use function is_object;
 
 /**
  * Factory for use in generating a custom FilterUsingXForwardedHeaders instance.
@@ -53,9 +50,7 @@ final class FilterUsingXForwardedHeadersFactory
 
         if (! is_array($proxies)) {
             // Invalid or missing configuration
-            throw Exception\InvalidTrustedProxyConfigurationException::forType(
-                is_object($proxies) ? get_class($proxies) : gettype($proxies)
-            );
+            throw Exception\InvalidTrustedProxyConfigurationException::forProxies($proxies);
         }
 
         // Missing trusted headers setting means all headers are considered trusted
@@ -68,9 +63,7 @@ final class FilterUsingXForwardedHeadersFactory
 
         if (! is_array($headers)) {
             // Invalid value; trust nothing
-            throw Exception\InvalidTrustedHeaderConfigurationException::forType(
-                is_object($headers) ? get_class($headers) : gettype($headers)
-            );
+            throw Exception\InvalidTrustedHeaderConfigurationException::forHeaders($headers);
         }
 
         return FilterUsingXForwardedHeaders::trustProxies($proxies, $headers);

--- a/src/Container/FilterUsingXForwardedHeadersFactory.php
+++ b/src/Container/FilterUsingXForwardedHeadersFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Container;
+
+use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
+use Mezzio\ConfigProvider;
+use Psr\Container\ContainerInterface;
+
+use function array_key_exists;
+use function is_array;
+use function is_string;
+
+/**
+ * Factory for use in generating a custom FilterUsingXForwardedHeaders instance.
+ *
+ * Assign this factory to the * Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface service.
+ * Then define configuration as follows:
+ *
+ * <code>
+ * 'laminas-diactoros' => [
+ *     'server-request-filter' => [
+ *         'x-forwarded-headers' => [
+ *             // Trust any proxy:
+ *             'trusted-proxies' => '*',
+ *             // Trust specific proxies:
+ *             'trusted-proxies' => ['192.168.0.1', '192.168.0.2'],
+ *             // Trust entire subnets:
+ *             'trusted-proxies' => ['192.168.0.0/24', '10.0.0.0/16'],
+ *             // Trust specific X-Forwared headers:
+ *             'trusted-headers' => ['X-Forwarded-Host', 'X-Forwarded-Proto'],
+ *         ],
+ *     ],
+ * ],
+ * </code>
+*/
+final class FilterUsingXForwardedHeadersFactory
+{
+    public function __invoke(ContainerInterface $container): FilterUsingXForwardedHeaders
+    {
+        // phpcs:disable Generic.Files.LineLength.TooLong
+        $config = $container->get('config');
+        $config = $config[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY][ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY] ?? [];
+
+        if (! is_array($config) || empty($config)) {
+            // Trust nothing!
+            return FilterUsingXForwardedHeaders::trustProxies([], []);
+        }
+
+        $proxies = array_key_exists(ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY, $config)
+            ? $config[ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY]
+            : [];
+
+        if (! is_string($proxies) && ! is_array($proxies)) {
+            // Invalid or missing configuration
+            return FilterUsingXForwardedHeaders::trustProxies([], []);
+        }
+
+        $proxies = is_string($proxies) ? [$proxies] : $proxies;
+
+        // Missing trusted headers setting means all headers are considered trusted
+        $headers = $config[ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY] ?? null;
+
+        if (null === $headers) {
+            // None specified; trust all headers for these proxies
+            return FilterUsingXForwardedHeaders::trustProxies($proxies);
+        }
+
+        if (! is_array($headers)) {
+            // Invalid value; trust nothing
+            return FilterUsingXForwardedHeaders::trustProxies([], []);
+        }
+
+        return FilterUsingXForwardedHeaders::trustProxies($proxies, $headers);
+        // phpcs:enable Generic.Files.LineLength.TooLong
+    }
+}

--- a/src/Container/FilterUsingXForwardedHeadersFactory.php
+++ b/src/Container/FilterUsingXForwardedHeadersFactory.php
@@ -8,8 +8,10 @@ use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
 use Mezzio\ConfigProvider;
 use Psr\Container\ContainerInterface;
 
+use function get_class;
+use function gettype;
 use function is_array;
-use function is_string;
+use function is_object;
 
 /**
  * Factory for use in generating a custom FilterUsingXForwardedHeaders instance.

--- a/src/Container/ServerRequestFactoryFactory.php
+++ b/src/Container/ServerRequestFactoryFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mezzio\Container;
 
 use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\ServerRequestFilter\ServerRequestFilterInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -19,6 +20,10 @@ use function sprintf;
  * allow vanilla PHP callable services. Instead, we wrap it in an
  * anonymous function here, which is allowed by all containers tested
  * at this time.
+ *
+ * This factory consumes the
+ * Laminas\Diactoros\ServerRequestFilter\ServerRequestFilterInterface
+ * service, which is used to make changes when initializing the request.
  */
 class ServerRequestFactoryFactory
 {
@@ -36,8 +41,12 @@ class ServerRequestFactoryFactory
             ));
         }
 
-        return function () {
-            return ServerRequestFactory::fromGlobals();
+        $filter = $container->has(ServerRequestFilterInterface::class)
+            ? $container->get(ServerRequestFilterInterface::class)
+            : null;
+
+        return function () use ($filter) {
+            return ServerRequestFactory::fromGlobals(null, null, null, null, null, $filter);
         };
     }
 }

--- a/src/Container/ServerRequestFactoryFactory.php
+++ b/src/Container/ServerRequestFactoryFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mezzio\Container;
 
 use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\ServerRequestFilter\ServerRequestFilterInterface;
+use Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -41,8 +41,8 @@ class ServerRequestFactoryFactory
             ));
         }
 
-        $filter = $container->has(ServerRequestFilterInterface::class)
-            ? $container->get(ServerRequestFilterInterface::class)
+        $filter = $container->has(FilterServerRequestInterface::class)
+            ? $container->get(FilterServerRequestInterface::class)
             : null;
 
         return function () use ($filter) {

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -102,6 +102,7 @@ class ConfigProviderTest extends TestCase
         }
 
         $config['dependencies']['services'][RouterInterface::class] = $this->createMock(RouterInterface::class);
+        $config['dependencies']['services']['config']               = $config;
         $container                                                  = $this->getContainer($config['dependencies']);
 
         $dependencies = $this->provider->getDependencies();

--- a/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
+++ b/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Container;
+
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
+use Mezzio\ConfigProvider;
+use Mezzio\Container\FilterUsingXForwardedHeadersFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+use function array_key_exists;
+
+class FilterUsingXForwardedHeadersFactoryTest extends TestCase
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    public function setUp(): void
+    {
+        $this->container = new class () implements ContainerInterface {
+            /** @psalm-var array<string, mixed> */
+            private array $services = [];
+
+            /**
+             * @param string $id
+             * @return bool
+             */
+            public function has($id)
+            {
+                return array_key_exists($id, $this->services);
+            }
+
+            /**
+             * @param string $id
+             * @return mixed
+             */
+            public function get($id)
+            {
+                if (! array_key_exists($id, $this->services)) {
+                    return null;
+                }
+
+                return $this->services[$id];
+            }
+
+            /** @param mixed $value */
+            public function set(string $id, $value): void
+            {
+                $this->services[$id] = $value;
+            }
+        };
+
+        $this->container->set('config', []);
+    }
+
+    public function generateServerRequest(array $headers, array $server, string $baseUrlString): ServerRequest
+    {
+        return new ServerRequest($server, [], $baseUrlString, 'GET', 'php://temp', $headers);
+    }
+
+    /** @psalm-return iterable<string, array{0: string}> */
+    public function randomIpGenerator(): iterable
+    {
+        yield 'class-a' => ['10.1.1.1'];
+        yield 'class-c' => ['192.168.1.1'];
+        yield 'localhost' => ['127.0.0.1'];
+        yield 'public' => ['4.4.4.4'];
+    }
+
+    /** @dataProvider randomIpGenerator */
+    public function testIfNoConfigPresentFactoryReturnsFilterThatDoesNotTrustAny(string $remoteAddr): void
+    {
+        $factory = new FilterUsingXForwardedHeadersFactory();
+        $filter  = $factory($this->container);
+        $request = $this->generateServerRequest(
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+            ],
+            [
+                'REMOTE_ADDR' => $remoteAddr,
+            ],
+            'http://localhost/foo/bar',
+        );
+
+        $filteredRequest = $filter($request);
+        $this->assertSame($request, $filteredRequest);
+    }
+
+    /** @psalm-return iterable<string, array{0: string, 1: array<string, string>}> */
+    public function trustAnyProvider(): iterable
+    {
+        $headers = [
+            FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+            FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+            FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+        ];
+
+        foreach ($this->randomIpGenerator() as $name => $arguments) {
+            $arguments[] = $headers;
+            yield $name => $arguments;
+        }
+    }
+
+    /** @dataProvider trustAnyProvider */
+    public function testIfWildcardProxyAddressSpecifiedReturnsFilterConfiguredToTrustAny(
+        string $remoteAddr,
+        array $headers
+    ): void {
+        $headers['Host'] = 'localhost';
+        $this->container->set('config', [
+            ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => '*',
+                    ],
+                ],
+            ],
+        ]);
+
+        $factory = new FilterUsingXForwardedHeadersFactory();
+        $filter  = $factory($this->container);
+        $request = $this->generateServerRequest(
+            $headers,
+            ['REMOTE_ADDR' => $remoteAddr],
+            'http://localhost/foo/bar',
+        );
+
+        $filteredRequest = $filter($request);
+        $this->assertNotSame($request, $filteredRequest);
+
+        $uri = $filteredRequest->getUri();
+        $this->assertSame($headers[FilterUsingXForwardedHeaders::HEADER_HOST], $uri->getHost());
+        // Port is always cast to int
+        $this->assertSame((int) $headers[FilterUsingXForwardedHeaders::HEADER_PORT], $uri->getPort());
+        $this->assertSame($headers[FilterUsingXForwardedHeaders::HEADER_PROTO], $uri->getScheme());
+    }
+
+    /** @dataProvider randomIpGenerator */
+    public function testEmptyProxiesListDoesNotTrustXForwardedRequests(string $remoteAddr): void
+    {
+        $this->container->set('config', [
+            ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => [],
+                        ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
+                            FilterUsingXForwardedHeaders::HEADER_HOST,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $factory = new FilterUsingXForwardedHeadersFactory();
+        $filter  = $factory($this->container);
+        $request = $this->generateServerRequest(
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+            ],
+            [
+                'REMOTE_ADDR' => $remoteAddr,
+            ],
+            'http://localhost/foo/bar',
+        );
+
+        $filteredRequest = $filter($request);
+        $this->assertSame($request, $filteredRequest);
+    }
+
+    /** @dataProvider randomIpGenerator */
+    public function testMissingHeadersListTrustsAllXForwardedRequestsForMatchedProxies(string $remoteAddr): void
+    {
+        $this->container->set('config', [
+            ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => ['0.0.0.0/0'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $factory = new FilterUsingXForwardedHeadersFactory();
+        $filter  = $factory($this->container);
+        $request = $this->generateServerRequest(
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            [
+                'REMOTE_ADDR' => $remoteAddr,
+            ],
+            'http://localhost/foo/bar',
+        );
+
+        $filteredRequest = $filter($request);
+        $this->assertNotSame($request, $filteredRequest);
+
+        $uri = $filteredRequest->getUri();
+        $this->assertSame('api.example.com', $uri->getHost());
+        $this->assertSame(4443, $uri->getPort());
+        $this->assertSame('https', $uri->getScheme());
+    }
+
+    /** @dataProvider randomIpGenerator */
+    public function testEmptyHeadersListTrustsNoRequests(string $remoteAddr): void
+    {
+        $this->container->set('config', [
+            ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => ['0.0.0.0/0'],
+                        ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [],
+                    ],
+                ],
+            ],
+        ]);
+
+        $factory = new FilterUsingXForwardedHeadersFactory();
+        $filter  = $factory($this->container);
+        $request = $this->generateServerRequest(
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            [
+                'REMOTE_ADDR' => $remoteAddr,
+            ],
+            'http://localhost/foo/bar',
+        );
+
+        $filteredRequest = $filter($request);
+        $this->assertSame($request, $filteredRequest);
+    }
+
+    /**
+     * @psalm-return iterable<string, array{
+     *     0: bool,
+     *     1: array<string, array<string, array<string, mixed>>>,
+     *     2: array<string, string>,
+     *     3: array<string, string>,
+     *     4: string,
+     *     5: string
+     * }>
+     */
+    public function trustedProxiesAndHeaders(): iterable
+    {
+        yield 'string-proxy-single-header' => [
+            false,
+            [
+                ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => '192.168.1.1',
+                            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
+                                FilterUsingXForwardedHeaders::HEADER_HOST,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            ['REMOTE_ADDR' => '192.168.1.1'],
+            'http://localhost/foo/bar',
+            'http://api.example.com/foo/bar',
+        ];
+
+        yield 'single-proxy-single-header' => [
+            false,
+            [
+                ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => ['192.168.1.1'],
+                            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
+                                FilterUsingXForwardedHeaders::HEADER_HOST,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            ['REMOTE_ADDR' => '192.168.1.1'],
+            'http://localhost/foo/bar',
+            'http://api.example.com/foo/bar',
+        ];
+
+        yield 'single-proxy-multi-header' => [
+            false,
+            [
+                ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => ['192.168.1.1'],
+                            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
+                                FilterUsingXForwardedHeaders::HEADER_HOST,
+                                FilterUsingXForwardedHeaders::HEADER_PROTO,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            ['REMOTE_ADDR' => '192.168.1.1'],
+            'http://localhost/foo/bar',
+            'https://api.example.com/foo/bar',
+        ];
+
+        yield 'unmatched-proxy-single-header' => [
+            true,
+            [
+                ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => ['192.168.1.1'],
+                            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
+                                FilterUsingXForwardedHeaders::HEADER_HOST,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            ['REMOTE_ADDR' => '192.168.2.1'],
+            'http://localhost/foo/bar',
+            'http://localhost/foo/bar',
+        ];
+
+        yield 'matches-proxy-from-list-single-header' => [
+            false,
+            [
+                ConfigProvider::DIACTOROS_CONFIG_KEY => [
+                    ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
+                        ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
+                            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => [
+                                '192.168.1.0/24',
+                                '192.168.2.0/24',
+                            ],
+                            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
+                                FilterUsingXForwardedHeaders::HEADER_HOST,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'Host'                                     => 'localhost',
+                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
+                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
+                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
+            ],
+            ['REMOTE_ADDR' => '192.168.2.1'],
+            'http://localhost/foo/bar',
+            'http://api.example.com/foo/bar',
+        ];
+    }
+
+    /** @dataProvider trustedProxiesAndHeaders */
+    public function testCombinedProxiesAndHeadersDefineTrust(
+        bool $expectUnfiltered,
+        array $config,
+        array $headers,
+        array $server,
+        string $baseUriString,
+        string $expectedUriString
+    ): void {
+        $this->container->set('config', $config);
+
+        $factory = new FilterUsingXForwardedHeadersFactory();
+        $filter  = $factory($this->container);
+        $request = $this->generateServerRequest($headers, $server, $baseUriString);
+
+        $filteredRequest = $filter($request);
+
+        if ($expectUnfiltered) {
+            $this->assertSame($request, $filteredRequest);
+            return;
+        }
+
+        $this->assertNotSame($request, $filteredRequest);
+        $this->assertSame($expectedUriString, $filteredRequest->getUri()->__toString());
+    }
+}

--- a/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
+++ b/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
@@ -116,7 +116,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
             ConfigProvider::DIACTOROS_CONFIG_KEY => [
                 ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
                     ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
-                        ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => '*',
+                        ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => ['*'],
                     ],
                 ],
             ],
@@ -256,31 +256,6 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
      */
     public function trustedProxiesAndHeaders(): iterable
     {
-        yield 'string-proxy-single-header' => [
-            false,
-            [
-                ConfigProvider::DIACTOROS_CONFIG_KEY => [
-                    ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY => [
-                        ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY => [
-                            ConfigProvider::DIACTOROS_TRUSTED_PROXIES_CONFIG_KEY => '192.168.1.1',
-                            ConfigProvider::DIACTOROS_TRUSTED_HEADERS_CONFIG_KEY => [
-                                FilterUsingXForwardedHeaders::HEADER_HOST,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'Host'                                     => 'localhost',
-                FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
-                FilterUsingXForwardedHeaders::HEADER_PROTO => 'https',
-                FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
-            ],
-            ['REMOTE_ADDR' => '192.168.1.1'],
-            'http://localhost/foo/bar',
-            'http://api.example.com/foo/bar',
-        ];
-
         yield 'single-proxy-single-header' => [
             false,
             [

--- a/test/Container/ServerRequestFactoryFactoryTest.php
+++ b/test/Container/ServerRequestFactoryFactoryTest.php
@@ -7,7 +7,6 @@ namespace MezzioTest\Container;
 use Closure;
 use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\ServerRequestFilter\DoNotFilter;
 use Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface;
 use Mezzio\Container\ServerRequestFactoryFactory;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

This patch adds support for the `FilterServerRequestInterface` in the `ServerRequestFactoryFactory`.
When the `FilterServerRequestInterface` service is defined, it will be used for the `$requestFilter` argument of Diactoros' `ServerRequestFactory::fromGlobals` factory.

Additionally, the patch adds a specialized factory for configuring a `FilterUsingXForwardedHeaders` to use for this service.
Users can configure it using the following configuration scheme:

```php
$config = [
    'laminas-diactoros' => [
        'server-request-filter' => [
            'x-forwarded-headers' => [
                'trusted-proxies' => string|string[],
                'trusted-headers' => string[],
            ],
        ],
    ],
    'dependencies' => [
        'factories' => [
            \Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface::class =>
                \Mezzio\Container\FilterUsingXForwardedHeadersFactory::class,
        ],
    ],
];
```

If they want to opt-out of usage of `X-Forwarded-*` headers entirely, they can now do so with the following configuration:

```php
$config = [
    'dependencies' => [
        'aliases' => [
            \Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface::class =>
                \Laminas\Diactoros\ServerRequestFilter\DoNotFilter::class,
        ],
    ],
];
```
