### PR TITLE
Docs: Fixed some grammar issues and typos

### DIFF
--- a/docs/book/v1/cookbook/debug-toolbars.md
+++ b/docs/book/v1/cookbook/debug-toolbars.md
@@ -16,7 +16,7 @@ as an extension to an existing PHP installation.
 
 When using Zend Server or the standalone Z-Ray, you do not need to make any
 changes to your application whatsoever to benefit from it; you simply need to
-make sure Z-Ray is enabled and/or that you've setup a security token to
+make sure Z-Ray is enabled and/or that you've set up a security token to
 selectively enable it on-demand. See the
 [Z-Ray documentation](http://files.zend.com/help/Zend-Server/content/z-ray_concept.htm)
 for full usage details.
@@ -86,4 +86,4 @@ one of two ways:
 > ### Use locally!
 >
 > Remember to enable `PhpMiddleware\PhpDebugBar\ConfigProvider` only in your
-> development enviroments!
+> development environments!

--- a/docs/book/v1/cookbook/setting-locale-depending-routing-parameter.md
+++ b/docs/book/v1/cookbook/setting-locale-depending-routing-parameter.md
@@ -1,4 +1,4 @@
-# How can I setup the locale depending on a routing parameter?
+# How can I set up the locale depending on a routing parameter?
 
 Localized web applications often set the locale (and therefor the language)
 based on a routing parameter, the session, or a specialized sub-domain.
@@ -15,7 +15,7 @@ In this recipe we will concentrate on using a routing parameter.
 
 ## Setting up the route
 
-If you want to set the locale depending on an routing parameter, you first have
+If you want to set the locale depending on a routing parameter, you first have
 to add a locale parameter to each route that requires localization.
 
 In this example we use the `locale` parameter, which should consist of two
@@ -101,7 +101,7 @@ return [
 
 ## Create a route result middleware class for localization
 
-To make sure that you can setup the locale after the routing has been processed,
+To make sure that you can set up the locale after the routing has been processed,
 you need to implement localization middleware that acts on the route result, and
 registered in the pipeline immediately following the routing middleware.
 

--- a/docs/book/v1/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v1/cookbook/setting-locale-without-routing-parameter.md
@@ -1,4 +1,4 @@
-# How can I setup the locale without routing parameters?
+# How can I set up the locale without routing parameters?
 
 Localized web applications often set the locale (and therefor the language)
 based on a routing parameter, the session, or a specialized sub-domain.
@@ -15,12 +15,12 @@ requiring any changes to existing routes.
 > with a required routing parameter; this approach is described in the
 > ["Setting a locale based on a routing parameter" recipe](setting-locale-depending-routing-parameter.md).
 
-## Setup a middleware to extract the locale from the URI
+## Set up a middleware to extract the locale from the URI
 
-First, we need to setup middleware that extracts the locale param directly
-from the request URI's path. If if doesn't find one, it sets a default.
+First, we need to set up middleware that extracts the locale param directly
+from the request URI's path. If it doesn't find one, it sets a default.
 
-If it does find one, it uses the value to setup the locale. It also:
+If it does find one, it uses the value to set up the locale. It also:
 
 - amends the request with a truncated path (removing the locale segment).
 - adds the locale segment as the base path of the `UrlHelper`.

--- a/docs/book/v1/features/application.md
+++ b/docs/book/v1/features/application.md
@@ -20,7 +20,7 @@ You can define the `Application` instance in several ways:
 - Via a dependency injection container; we provide a factory for setting up all
   aspects of the instance via configuration and other defined services.
 
-Regardless of how you setup the instance, there are several methods you will
+Regardless of how you set up the instance, there are several methods you will
 likely interact with at some point or another.
 
 ## Instantiation

--- a/docs/book/v1/features/container/factories.md
+++ b/docs/book/v1/features/container/factories.md
@@ -288,7 +288,7 @@ the `TwigExtension` instance (assuming the router was found).
 - **Optional**:
     - `config`, an array or `ArrayAccess` instance. This will be used to further
       configure the `LaminasView` instance, specifically with the layout template
-      name, entries for a `TemplateMapResolver`, and and template paths to
+      name, entries for a `TemplateMapResolver`, and template paths to
       inject.
     - `Laminas\View\HelperPluginManager`; if present, will be used to inject the
       `PhpRenderer` instance.
@@ -314,4 +314,4 @@ When creating the `PhpRenderer` instance, it will inject it with a
 `Laminas\View\HelperPluginManager` instance (either pulled from the container, or
 instantiated directly). It injects the helper plugin manager with custom url and
 serverurl helpers, `Mezzio\LaminasView\UrlHelper` and
-`Mezzio\LaminasView\ServerUrlHelper`, respetively.
+`Mezzio\LaminasView\ServerUrlHelper`, respectively.

--- a/docs/book/v1/features/error-handling.md
+++ b/docs/book/v1/features/error-handling.md
@@ -41,7 +41,7 @@ First, of course, you'll need to select a templating system and ensure you have
 the appropriate dependencies installed; see the [templating documentation](template/intro.md)
 for information on what we support and how to install supported systems.
 
-Once you have selected your templating system, you can setup the templated error
+Once you have selected your templating system, you can set up the templated error
 handler.
 
 ```php

--- a/docs/book/v1/features/router/fast-route.md
+++ b/docs/book/v1/features/router/fast-route.md
@@ -47,7 +47,7 @@ If you need greater control over the FastRoute setup and configuration, you
 can create the instances necessary and inject them into
 `Mezzio\Router\FastRouteRouter` during instantiation.
 
-To do so, you will need to setup your `RouteCollector` instance and/or
+To do so, you will need to set up your `RouteCollector` instance and/or
 optionally callable to return your `RegexBasedAbstract` instance manually,
 inject them in your `Mezzio\Router\FastRouteRouter` instance, and inject use
 that when creating your `Application` instance.

--- a/docs/book/v1/getting-started/features.md
+++ b/docs/book/v1/getting-started/features.md
@@ -72,7 +72,7 @@ Below is a diagram detailing the workflow used by Mezzio.
 ![Mezzio Architectural Flow](../../images/architecture.png)
 
 The `Application` acts as an "onion"; in the diagram above, the top is the
-outer-most layer of the onion, while the bottom is the inner-most.
+outermost layer of the onion, while the bottom is the innermost.
 
 The `Application` dispatches each middleware. Each middleware accepts a
 *request*, a *response*, and the *next* middleware to dispatch. Internally,
@@ -94,8 +94,8 @@ argument to act on.
 > looked at from this perspective:
 >
 > - In most cases, the entire queue *will not* be traversed.
-> - The inner-most layer of the onion represents the last item in the queue.
-> - Responses are returned back *through* the pipeline, in reverse order of
+> - The innermost layer of the onion represents the last item in the queue.
+> - Responses are returned *through* the pipeline, in reverse order of
 >   traversal.
 
 The `Application` allows arbitrary middleware to be injected, with each being

--- a/docs/book/v1/getting-started/standalone.md
+++ b/docs/book/v1/getting-started/standalone.md
@@ -48,8 +48,8 @@ $ mkdir public
 
 ## 4. Create your bootstrap script
 
-Next, we'll create a bootstrap script. Such scripts typically setup the
-environment, setup the application, and invoke it. This needs to be in our web
+Next, we'll create a bootstrap script. Such scripts typically set up the
+environment, set up the application, and invoke it. This needs to be in our web
 root, and we want it to intercept any incoming request; as such, we'll use
 `public/index.php`:
 
@@ -76,7 +76,7 @@ $app->run();
 > ### Rewriting URLs
 >
 > Many web servers will not rewrite URLs to the bootstrap script by default. If
-> you use Apache, for instance, you'll need to setup rewrite rules to ensure
+> you use Apache, for instance, you'll need to set up rewrite rules to ensure
 > your bootstrap is invoked for unknown URLs. We'll cover that in a later
 > chapter.
 

--- a/docs/book/v1/reference/migration/rc-to-v1.md
+++ b/docs/book/v1/reference/migration/rc-to-v1.md
@@ -12,7 +12,7 @@ RC6 introduced changes to the following:
   failures.
 - Middleware configuration specifications now accept a `priority` key to
   guarantee the order of items. If you have defined your middleware pipeline in
-  multiple files that are then merged, you will need to defined these keys to
+  multiple files that are then merged, you will need to define these keys to
   ensure order.
 
 ## Routing and Dispatch middleware

--- a/docs/book/v1/reference/migration/to-v1-1.md
+++ b/docs/book/v1/reference/migration/to-v1-1.md
@@ -41,7 +41,7 @@ will be removed for the 2.0 release:
   `Mezzio\Exception\InvalidArgumentException` instead.
 
 - `Mezzio\Container\Exception\NotFoundException`: this exception type
-  is not currently used anyways.
+  is not currently used anyway.
 
 - `Mezzio\ErrorMiddlewarePipe`: Stratigility v1 error middleware are
   removed in the Stratigility v2 release, which Mezzio 2.0 will adopt,

--- a/docs/book/v1/reference/usage-examples.md
+++ b/docs/book/v1/reference/usage-examples.md
@@ -411,7 +411,7 @@ $app->run();
 ```
 
 Notice that our index file now doesn't have any code related to setting up the
-application any longer! All it does is setup autoloading, retrieve our service
+application any longer! All it does is set up autoloading, retrieve our service
 container, pull the application from it, and run it. Our choices for container,
 router, etc. are all abstracted, and if we change our mind later, this code will
 continue to work.

--- a/docs/book/v2/cookbook/debug-toolbars.md
+++ b/docs/book/v2/cookbook/debug-toolbars.md
@@ -16,7 +16,7 @@ as an extension to an existing PHP installation.
 
 When using Zend Server or the standalone Z-Ray, you do not need to make any
 changes to your application whatsoever to benefit from it; you simply need to
-make sure Z-Ray is enabled and/or that you've setup a security token to
+make sure Z-Ray is enabled and/or that you've set up a security token to
 selectively enable it on-demand. See the
 [Z-Ray documentation](http://files.zend.com/help/Zend-Server/content/z-ray_concept.htm)
 for full usage details.
@@ -78,4 +78,4 @@ return $provider();
 > ### Use locally!
 >
 > Remember to enable `PhpMiddleware\PhpDebugBar\ConfigProvider` only in your
-> development enviroments!
+> development environments!

--- a/docs/book/v2/cookbook/setting-locale-depending-routing-parameter.md
+++ b/docs/book/v2/cookbook/setting-locale-depending-routing-parameter.md
@@ -1,4 +1,4 @@
-# How can I setup the locale depending on a routing parameter?
+# How can I set up the locale depending on a routing parameter?
 
 Localized web applications often set the locale (and therefor the language)
 based on a routing parameter, the session, or a specialized sub-domain.
@@ -15,7 +15,7 @@ In this recipe we will concentrate on using a routing parameter.
 
 ## Setting up the route
 
-If you want to set the locale depending on an routing parameter, you first have
+If you want to set the locale depending on a routing parameter, you first have
 to add a locale parameter to each route that requires localization.
 
 In the following examples, we use the `locale` parameter, which should consist
@@ -128,7 +128,7 @@ return [
 
 ## Create a route result middleware class for localization
 
-To make sure that you can setup the locale after the routing has been processed,
+To make sure that you can set up the locale after the routing has been processed,
 you need to implement localization middleware that acts on the route result, and
 registered in the pipeline immediately following the routing middleware.
 

--- a/docs/book/v2/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v2/cookbook/setting-locale-without-routing-parameter.md
@@ -1,4 +1,4 @@
-# How can I setup the locale without routing parameters?
+# How can I set up the locale without routing parameters?
 
 Localized web applications often set the locale (and therefore the language)
 based on a routing parameter, the session, or a specialized sub-domain.
@@ -15,12 +15,12 @@ requiring any changes to existing routes.
 > with a required routing parameter; this approach is described in the
 > ["Setting a locale based on a routing parameter" recipe](setting-locale-depending-routing-parameter.md).
 
-## Setup a middleware to extract the locale from the URI
+## Set up a middleware to extract the locale from the URI
 
-First, we need to setup middleware that extracts the locale param directly
-from the request URI's path. If if doesn't find one, it sets a default.
+First, we need to set up middleware that extracts the locale param directly
+from the request URI's path. If it doesn't find one, it sets a default.
 
-If it does find one, it uses the value to setup the locale. It also:
+If it does find one, it uses the value to set up the locale. It also:
 
 - amends the request with a truncated path (removing the locale segment).
 - adds the locale segment as the base path of the `UrlHelper`.

--- a/docs/book/v2/features/application.md
+++ b/docs/book/v2/features/application.md
@@ -21,7 +21,7 @@ You can define the `Application` instance in several ways:
 - Via a dependency injection container; we provide a factory for setting up all
   aspects of the instance via configuration and other defined services.
 
-Regardless of how you setup the instance, there are several methods you will
+Regardless of how you set up the instance, there are several methods you will
 likely interact with at some point or another.
 
 ## Instantiation
@@ -232,7 +232,7 @@ methods for retrieving them. They include:
   [emitter](https://docs.laminas.dev/laminas-diactoros/emitting-responses/),
   typically a `Mezzio\Emitter\EmitterStack` instance.
 - `getDefaultDelegate()`: retrieves the default delegate to use when the internal middleware pipeline is exhausted without returning a response. If none is provided at instantiation, this method will do one of the following:
-    - If no container is composed, instanatiates a
+    - If no container is composed, instantiates a
       `Mezzio\Delegate\NotFoundDelegate` using the composed response
       prototype only.
     - If a container is composed, but does not have the

--- a/docs/book/v2/features/container/factories.md
+++ b/docs/book/v2/features/container/factories.md
@@ -361,7 +361,7 @@ the `TwigExtension` instance (assuming the router was found).
 - **Optional**:
     - `config`, an array or `ArrayAccess` instance. This will be used to further
       configure the `LaminasView` instance, specifically with the layout template
-      name, entries for a `TemplateMapResolver`, and and template paths to
+      name, entries for a `TemplateMapResolver`, and template paths to
       inject.
     - `Laminas\View\HelperPluginManager`; if present, will be used to inject the
       `PhpRenderer` instance.

--- a/docs/book/v2/features/router/fast-route.md
+++ b/docs/book/v2/features/router/fast-route.md
@@ -47,7 +47,7 @@ If you need greater control over the FastRoute setup and configuration, you
 can create the instances necessary and inject them into
 `Mezzio\Router\FastRouteRouter` during instantiation.
 
-To do so, you will need to setup your `RouteCollector` instance and/or
+To do so, you will need to set up your `RouteCollector` instance and/or
 optionally callable to return your `RegexBasedAbstract` instance manually,
 inject them in your `Mezzio\Router\FastRouteRouter` instance, and inject use
 that when creating your `Application` instance.

--- a/docs/book/v2/getting-started/features.md
+++ b/docs/book/v2/getting-started/features.md
@@ -72,7 +72,7 @@ Below is a diagram detailing the workflow used by Mezzio.
 ![Mezzio Architectural Flow](../../images/architecture.png)
 
 The `Application` acts as an "onion"; in the diagram above, the top is the
-outer-most layer of the onion, while the bottom is the inner-most.
+outermost layer of the onion, while the bottom is the innermost.
 
 The `Application` dispatches each middleware. Each middleware receives a request
 and a delegate for handing off processing of the request should the middleware
@@ -91,11 +91,11 @@ its way back out the onion.
 > looked at from this perspective:
 >
 > - In most cases, the entire queue *will not* be traversed.
-> - The inner-most layer of the onion represents the last item in the queue, and
+> - The innermost layer of the onion represents the last item in the queue, and
 >   should be guaranteed to return a response; usually this is indicative of
 >   a malformed request (HTTP 400 response status) and/or inability to route
 >   the middleware to a handler (HTTP 404 response status).
-> - Responses are returned back *through* the pipeline, in reverse order of
+> - Responses are returned *through* the pipeline, in reverse order of
 >   traversal.
 
 > ### Double pass middleware

--- a/docs/book/v2/getting-started/skeleton.md
+++ b/docs/book/v2/getting-started/skeleton.md
@@ -32,7 +32,7 @@ This will prompt you to choose:
   Plates in the examples below, so choose it if you want to code along).
 
 - An error handler. Whoops is a very nice option for development, as it gives
-  you extensive, browseable information for exceptions and errors raised.
+  you extensive, browsable information for exceptions and errors raised.
 
 ## Start a web server
 
@@ -285,7 +285,7 @@ your middleware.
 
 [Piping](../features/router/piping.md#piping) is a foundation feature of the
 underlying [laminas-stratigility](https://docs.laminas.dev/laminas-stratigility/)
-implementation. You can setup the middleware pipeline in `config/pipeline.php`.
+implementation. You can set up the middleware pipeline in `config/pipeline.php`.
 In this section, we'll demonstrate setting up a basic pipeline that includes
 error handling, segregated applications, routing, middleware dispatch, and more.
 
@@ -389,7 +389,7 @@ $app->pipe(NotFoundHandler::class);
 ### Routing
 
 [Routing](../features/router/piping.md#routing) is an additional feature
-provided by Mezzio. Routing is setup in `config/routes.php`.
+provided by Mezzio. Routing is set up in `config/routes.php`.
 
 You can setup routes with a single request method:
 

--- a/docs/book/v2/getting-started/standalone.md
+++ b/docs/book/v2/getting-started/standalone.md
@@ -55,8 +55,8 @@ $ mkdir public
 
 ## 4. Create your bootstrap script
 
-Next, we'll create a bootstrap script. Such scripts typically setup the
-environment, setup the application, and invoke it. This needs to be in our web
+Next, we'll create a bootstrap script. Such scripts typically set up the
+environment, set up the application, and invoke it. This needs to be in our web
 root, and we want it to intercept any incoming request; as such, we'll use
 `public/index.php`:
 
@@ -84,7 +84,7 @@ $app->run();
 > ### Rewriting URLs
 >
 > Many web servers will not rewrite URLs to the bootstrap script by default. If
-> you use Apache, for instance, you'll need to setup rewrite rules to ensure
+> you use Apache, for instance, you'll need to set up rewrite rules to ensure
 > your bootstrap is invoked for unknown URLs. We'll cover that in a later
 > chapter.
 

--- a/docs/book/v2/reference/migration.md
+++ b/docs/book/v2/reference/migration.md
@@ -409,7 +409,7 @@ handling needs:
   get to the innermost layer, no middleware was able to handle the request,
   indicating a 404.) By default, it will produce a canned plaintext response.
   However, you can also provide an optional `TemplateRendererInterface` instance
-  and `$template` in order to provided templated content.<br/><br/>
+  and `$template` in order to provide templated content.<br/><br/>
   The constructor arguments are:
 
     - `ResponseInterface $responsePrototype`: this is an empty response on which

--- a/docs/book/v2/reference/usage-examples.md
+++ b/docs/book/v2/reference/usage-examples.md
@@ -415,7 +415,7 @@ $app->run();
 ```
 
 Notice that our index file now doesn't have any code related to setting up the
-application any longer! All it does is setup autoloading, retrieve our service
+application any longer! All it does is set up autoloading, retrieve our service
 container, pull the application from it, and run it. Our choices for container,
 router, etc. are all abstracted, and if we change our mind later, this code will
 continue to work.

--- a/docs/book/v3/cookbook/access-common-data-in-templates.md
+++ b/docs/book/v3/cookbook/access-common-data-in-templates.md
@@ -3,13 +3,13 @@
 Templates often need access to common request data, such as request attributes,
 the current route name, the currently authenticated user, and more. Wrangling
 all of that data in every single handler, however, often leads to code
-duplication, and the possibility of accidently omitting some of that data. How
+duplication, and the possibility of accidentally omitting some of that data. How
 can you make such data available to all templates?
 
 The approach detailed in this recipe involves creating a middleware that calls
 on the template renderer's `addDefaultParam()` method.
 
-Foolowing is an example that injects the current user, the matched route name,
+The following is an example that injects the current user, the matched route name,
 and all flash messages via a single middleware.
 
 ```php

--- a/docs/book/v3/cookbook/debug-toolbars.md
+++ b/docs/book/v3/cookbook/debug-toolbars.md
@@ -3,7 +3,7 @@
 Many modern frameworks and applications provide debug toolbars: in-browser
 toolbars to provide profiling information of the request executed. These can
 provide invaluable details into application objects, database queries, and more.
-As an Mezzio user, how can you get similar functionality?
+As a Mezzio user, how can you get similar functionality?
 
 ## Zend Server Z-Ray
 
@@ -16,7 +16,7 @@ as an extension to an existing PHP installation.
 
 When using Zend Server or the standalone Z-Ray, you do not need to make any
 changes to your application whatsoever to benefit from it; you simply need to
-make sure Z-Ray is enabled and/or that you've setup a security token to
+make sure Z-Ray is enabled and/or that you've set up a security token to
 selectively enable it on-demand. See the
 [Z-Ray documentation](http://files.zend.com/help/Zend-Server/content/z-ray_concept.htm)
 for full usage details.

--- a/docs/book/v3/cookbook/double-pass-middleware.md
+++ b/docs/book/v3/cookbook/double-pass-middleware.md
@@ -29,13 +29,13 @@ this middleware with Mezzio 3?
 laminas-stratigility v2.2 and v3.0 ship a utility function,
 `Laminas\Stratigility\doublePassMiddleware()`, that will decorate a callable
 double-pass middleware using a `Laminas\Stratigility\Middleware\DoublePassMiddlewareDecorator`
-instance; this latter is a PSR-15 impelementation, and can thus be used in your
+instance; this latter is a PSR-15 implementation, and can thus be used in your
 middleware pipelines.
 
 The function (and class) also expects a [PSR-7](https://www.php-fig.org/psr/psr-7/)
 `ResponseInterface` instance as a second argument; this is then passed as the
 `$response` argument to the double-pass middleware. The following examples
-demostrate both piping and routing to double pass middleware using this
+demonstrate both piping and routing to double pass middleware using this
 technique, and using laminas-diactoros to provide the response instance.
 
 ```php

--- a/docs/book/v3/cookbook/host-segregated-middleware.md
+++ b/docs/book/v3/cookbook/host-segregated-middleware.md
@@ -1,7 +1,7 @@
 # How does one segregate middleware by host?
 
 If your application is being re-used to respond to multiple host domains, how
-can you segregate middleware to work only in reponse to a specific host request?
+can you segregate middleware to work only in response to a specific host request?
 
 As an example, perhaps you have an "admin" area of your application you only
 want to expose via the host name "admin.example.org"; how can you do this?

--- a/docs/book/v3/cookbook/setting-locale-depending-routing-parameter.md
+++ b/docs/book/v3/cookbook/setting-locale-depending-routing-parameter.md
@@ -1,4 +1,4 @@
-# How can I setup the locale depending on a routing parameter?
+# How can I set up the locale depending on a routing parameter?
 
 Localized web applications often set the locale (and therefor the language)
 based on a routing parameter, the session, or a specialized sub-domain.
@@ -15,7 +15,7 @@ In this recipe we will concentrate on using a routing parameter.
 
 ## Setting up the route
 
-If you want to set the locale depending on an routing parameter, you first have
+If you want to set the locale depending on a routing parameter, you first have
 to add a locale parameter to each route that requires localization.
 
 In the following examples, we use the `locale` parameter, which should consist
@@ -87,7 +87,7 @@ $app->get('/:locale/contact', ContactPageHandler::class, 'contact')
 
 ## Create a route result middleware class for localization
 
-To make sure that you can setup the locale after the routing has been processed,
+To make sure that you can set up the locale after the routing has been processed,
 you need to implement localization middleware that acts on the route result, and
 registered in the pipeline immediately following the routing middleware.
 

--- a/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
@@ -1,4 +1,4 @@
-# How can I setup the locale without routing parameters?
+# How can I set up the locale without routing parameters?
 
 Localized web applications often set the locale (and therefore the language)
 based on a routing parameter, the session, or a specialized sub-domain.
@@ -15,12 +15,12 @@ requiring any changes to existing routes.
 > with a required routing parameter; this approach is described in the
 > ["Setting a locale based on a routing parameter" recipe](setting-locale-depending-routing-parameter.md).
 
-## Setup a middleware to extract the locale from the URI
+## Set up a middleware to extract the locale from the URI
 
-First, we need to setup middleware that extracts the locale param directly
+First, we need to set up middleware that extracts the locale param directly
 from the request URI's path. If it doesn't find one, it sets a default.
 
-If it does find one, it uses the value to setup the locale. It also:
+If it does find one, it uses the value to set up the locale. It also:
 
 - amends the request with a truncated path (removing the locale segment).
 - adds the locale segment as the base path of the `UrlHelper`.

--- a/docs/book/v3/features/application.md
+++ b/docs/book/v3/features/application.md
@@ -22,7 +22,7 @@ You can define the `Application` instance in two ways:
 - Via a dependency injection container; we provide a factory for setting up all
   aspects of the instance via configuration and other defined services.
 
-Regardless of how you setup the instance, there are several methods you will
+Regardless of how you set up the instance, there are several methods you will
 likely interact with at some point or another.
 
 ## Instantiation

--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -489,7 +489,7 @@ the `TwigExtension` instance (assuming the router was found).
 - **Optional**:
     - `config`, an array or `ArrayAccess` instance. This will be used to further
       configure the `LaminasView` instance, specifically with the layout template
-      name, entries for a `TemplateMapResolver`, and and template paths to
+      name, entries for a `TemplateMapResolver`, and template paths to
       inject.
     - `Laminas\View\Renderer\PhpRenderer`, in order to allow providing custom
       extensions and/or re-using an existing configuration; otherwise, a default

--- a/docs/book/v3/getting-started/features.md
+++ b/docs/book/v3/getting-started/features.md
@@ -16,7 +16,7 @@ maintain.
 
 PSR-15 also defines _request handlers_; these are classes that receive a
 request and return a response, without delegating to other layers of the
-application. These are generally the inner-most layers of your application.
+application. These are generally the innermost layers of your application.
 
 Middleware is also designed for composability; you should be able to nest
 middleware and re-use middleware.
@@ -77,7 +77,7 @@ Below is a diagram detailing the workflow used by Mezzio.
 ![Mezzio Architectural Flow](../../images/architecture.png)
 
 The `Application` acts as an "onion"; in the diagram above, the top is the
-outer-most layer of the onion, while the bottom is the inner-most.
+outermost layer of the onion, while the bottom is the innermost.
 
 The `Application` dispatches each middleware. Each middleware receives a request
 and a delegate for handing off processing of the request should the middleware
@@ -96,11 +96,11 @@ its way back out the onion.
 > looked at from this perspective:
 >
 > - In most cases, the entire queue *will not* be traversed.
-> - The inner-most layer of the onion represents the last item in the queue, and
+> - The innermost layer of the onion represents the last item in the queue, and
 >   should be guaranteed to return a response; usually this is indicative of
 >   a malformed request (HTTP 400 response status) and/or inability to route
 >   the middleware to a handler (HTTP 404 response status).
-> - Responses are returned back *through* the pipeline, in reverse order of
+> - Responses are returned *through* the pipeline, in reverse order of
 >   traversal.
 
 > ### Double pass middleware

--- a/docs/book/v3/getting-started/quick-start.md
+++ b/docs/book/v3/getting-started/quick-start.md
@@ -32,7 +32,7 @@ This will prompt you to choose:
   Plates.
 
 - An error handler. Whoops is a very nice option for development, as it gives
-  you extensive, browseable information for exceptions and errors raised.
+  you extensive, browsable information for exceptions and errors raised.
 
 ## Start a web server
 
@@ -288,7 +288,7 @@ your middleware.
 
 [Piping](../features/router/piping.md#piping) is a foundation feature of the
 underlying [laminas-stratigility](https://docs.laminas.dev/laminas-stratigility/)
-implementation. You can setup the middleware pipeline in `config/pipeline.php`.
+implementation. You can set up the middleware pipeline in `config/pipeline.php`.
 In this section, we'll demonstrate setting up a basic pipeline that includes
 error handling, segregated applications, routing, middleware dispatch, and more.
 
@@ -408,7 +408,7 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
 ### Routing
 
 [Routing](../features/router/piping.md#routing) is an additional feature
-provided by Mezzio. Routing is setup in `config/routes.php`.
+provided by Mezzio. Routing is set up in `config/routes.php`.
 
 You can setup routes with a single request method:
 

--- a/docs/book/v3/reference/migration.md
+++ b/docs/book/v3/reference/migration.md
@@ -38,7 +38,7 @@ changes were made throughout Mezzio:
   `\Psr\Http\Message\ResponseInterface`.
 
 This change also affects all middleware you, as an application developer, have
-written, and your middleware will need to be update. We provide a tool for this
+written, and your middleware will need to be updated. We provide a tool for this
 via mezzio-tooling. Make sure that package is up-to-date (a version 1
 release should be installed), and run the following:
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
I found several grammar errors and typos within the documentation and rectified them :-)
