### PR TITLE
Update locked deps, Static analysis fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # mezzio
 
 [![Build Status](https://github.com/mezzio/mezzio/workflows/Continuous%20Integration/badge.svg)](https://github.com/mezzio/mezzio/actions?query=workflow%3A"Continuous+Integration")
+[![Type Coverage](https://shepherd.dev/github/mezzio/mezzio/coverage.svg)](https://shepherd.dev/github/mezzio/mezzio)
 
 *Develop PSR-7 middleware applications in minutes!*
 

--- a/composer.json
+++ b/composer.json
@@ -50,17 +50,17 @@
         "webmozart/assert": "^1.10"
     },
     "require-dev": {
-        "filp/whoops": "^2.14.5",
+        "filp/whoops": "^2.14.6",
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-diactoros": "^2.19",
-        "laminas/laminas-servicemanager": "^3.15",
-        "mezzio/mezzio-aurarouter": "^3.5",
-        "mezzio/mezzio-fastroute": "^3.7",
+        "laminas/laminas-diactoros": "^2.24",
+        "laminas/laminas-servicemanager": "^3.20",
+        "mezzio/mezzio-aurarouter": "^3.6",
+        "mezzio/mezzio-fastroute": "^3.8",
         "mezzio/mezzio-laminasrouter": "^3.7",
         "mockery/mockery": "^1.5.1",
-        "phpunit/phpunit": "^9.5.26",
-        "psalm/plugin-phpunit": "^0.18",
-        "vimeo/psalm": "^5.0.0"
+        "phpunit/phpunit": "^9.5.27",
+        "psalm/plugin-phpunit": "^0.18.4",
+        "vimeo/psalm": "^5.4"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "mezzio/mezzio-aurarouter": "^3.6",
         "mezzio/mezzio-fastroute": "^3.8",
         "mezzio/mezzio-laminasrouter": "^3.7",
-        "mockery/mockery": "^1.5.1",
         "phpunit/phpunit": "^9.5.27",
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "272da90b37717338a45aac555bfee0f1",
+    "content-hash": "f10c7ab72049b19dfcd6a5894d25d218",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -64,16 +64,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.23.0",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "a738cecb420e3bcff34c33177f1ce9f68902695c"
+                "reference": "6028af6c3b5ced4d063a680d2483cce67578b902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/a738cecb420e3bcff34c33177f1ce9f68902695c",
-                "reference": "a738cecb420e3bcff34c33177f1ce9f68902695c",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/6028af6c3b5ced4d063a680d2483cce67578b902",
+                "reference": "6028af6c3b5ced4d063a680d2483cce67578b902",
                 "shasum": ""
             },
             "require": {
@@ -96,9 +96,9 @@
                 "http-interop/http-factory-tests": "^0.9.0",
                 "laminas/laminas-coding-standard": "^2.4.0",
                 "php-http/psr7-integration-tests": "^1.2",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "extra": {
@@ -157,7 +157,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-14T22:31:50+00:00"
+            "time": "2022-12-20T12:22:40+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -223,16 +223,16 @@
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-                "reference": "d15af53895fd581b5a448a09fd9a4baebc4ae6e5"
+                "reference": "7a47834aaad7852816d2ec4fdbb0492163b039ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/d15af53895fd581b5a448a09fd9a4baebc4ae6e5",
-                "reference": "d15af53895fd581b5a448a09fd9a4baebc4ae6e5",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/7a47834aaad7852816d2ec4fdbb0492163b039ae",
+                "reference": "7a47834aaad7852816d2ec4fdbb0492163b039ae",
                 "shasum": ""
             },
             "require": {
@@ -244,9 +244,9 @@
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
                 "laminas/laminas-diactoros": "^2.18",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.28"
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^5.0.0"
             },
             "type": "library",
             "extra": {
@@ -286,7 +286,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-25T13:41:39+00:00"
+            "time": "2023-01-05T21:54:03+00:00"
         },
         {
             "name": "laminas/laminas-stratigility",
@@ -370,16 +370,16 @@
         },
         {
             "name": "mezzio/mezzio-router",
-            "version": "3.10.0",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-router.git",
-                "reference": "f98d3e97b0e949d394703e526bf218402be601bf"
+                "reference": "a30bb059261e6d1d980bcd35b4f8ed537cf8087f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/f98d3e97b0e949d394703e526bf218402be601bf",
-                "reference": "f98d3e97b0e949d394703e526bf218402be601bf",
+                "url": "https://api.github.com/repos/mezzio/mezzio-router/zipball/a30bb059261e6d1d980bcd35b4f8ed537cf8087f",
+                "reference": "a30bb059261e6d1d980bcd35b4f8ed537cf8087f",
                 "shasum": ""
             },
             "require": {
@@ -396,12 +396,12 @@
                 "zendframework/zend-expressive-router": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-diactoros": "^2.20.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-diactoros": "^2.24",
                 "laminas/laminas-stratigility": "^3.9.0",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.4"
             },
             "suggest": {
                 "mezzio/mezzio-aurarouter": "^3.0 to use the Aura.Router routing adapter",
@@ -447,7 +447,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-13T20:50:07+00:00"
+            "time": "2023-01-12T15:10:48+00:00"
         },
         {
             "name": "mezzio/mezzio-template",
@@ -515,27 +515,22 @@
         },
         {
             "name": "psr/container",
-            "version": "2.0.2",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
-                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -562,9 +557,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/2.0.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-11-05T16:47:00+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1472,30 +1467,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1522,7 +1517,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -1538,7 +1533,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -2003,21 +1998,21 @@
         },
         {
             "name": "laminas/laminas-psr7bridge",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-psr7bridge.git",
-                "reference": "6a653713d0b08b0b2e3fc89b61e0516ebe1966f5"
+                "reference": "fa4bdcc88727e37d51dedb7ddd0c5e9803d792b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-psr7bridge/zipball/6a653713d0b08b0b2e3fc89b61e0516ebe1966f5",
-                "reference": "6a653713d0b08b0b2e3fc89b61e0516ebe1966f5",
+                "url": "https://api.github.com/repos/laminas/laminas-psr7bridge/zipball/fa4bdcc88727e37d51dedb7ddd0c5e9803d792b4",
+                "reference": "fa4bdcc88727e37d51dedb7ddd0c5e9803d792b4",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-diactoros": "^2.0",
-                "laminas/laminas-http": "^2.15",
+                "laminas/laminas-http": "^2.18",
                 "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
                 "psr/http-message": "^1.0"
             },
@@ -2027,9 +2022,9 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.28"
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -2063,20 +2058,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-11T00:15:30+00:00"
+            "time": "2022-12-20T12:37:06+00:00"
         },
         {
             "name": "laminas/laminas-router",
-            "version": "3.11.0",
+            "version": "3.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-router.git",
-                "reference": "48b6fccd63b9e04e67781c212bf3bedd75c9ca17"
+                "reference": "3512c28cb4ffd64a62bc9e8b685a50a6547b0a11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/48b6fccd63b9e04e67781c212bf3bedd75c9ca17",
-                "reference": "48b6fccd63b9e04e67781c212bf3bedd75c9ca17",
+                "url": "https://api.github.com/repos/laminas/laminas-router/zipball/3512c28cb4ffd64a62bc9e8b685a50a6547b0a11",
+                "reference": "3512c28cb4ffd64a62bc9e8b685a50a6547b0a11",
                 "shasum": ""
             },
             "require": {
@@ -2134,27 +2129,26 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-02T17:45:59+00:00"
+            "time": "2022-12-29T14:47:23+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.15.0",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "65910ef6a8066b0369fab77fbec9e030be59c866"
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/65910ef6a8066b0369fab77fbec9e030be59c866",
-                "reference": "65910ef6a8066b0369fab77fbec9e030be59c866",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
+                "reference": "bc2c2cbe2dd90db8b9d16b0618f542692b76ab59",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^2.0",
                 "laminas/laminas-stdlib": "^3.2.1",
-                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
-                "psr/container": "^1.1 || ^2.0.2"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "psr/container": "^1.0"
             },
             "conflict": {
                 "ext-psr": "*",
@@ -2163,21 +2157,22 @@
                 "zendframework/zend-servicemanager": "*"
             },
             "provide": {
-                "psr/container-implementation": "^1.1 || ^2.0"
+                "psr/container-implementation": "^1.0"
             },
             "replace": {
                 "container-interop/container-interop": "^1.2.0"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "laminas/laminas-container-config-test": "^0.6",
-                "mikey179/vfsstream": "^1.6.10@alpha",
-                "ocramius/proxy-manager": "^2.11",
-                "phpbench/phpbench": "^1.1",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.8"
+                "composer/package-versions-deprecated": "^1.11.99.5",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-container-config-test": "^0.8",
+                "laminas/laminas-dependency-plugin": "^2.2",
+                "mikey179/vfsstream": "^1.6.11@alpha",
+                "ocramius/proxy-manager": "^2.14.1",
+                "phpbench/phpbench": "^1.2.7",
+                "phpunit/phpunit": "^9.5.26",
+                "psalm/plugin-phpunit": "^0.18.0",
+                "vimeo/psalm": "^5.0.0"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -2224,7 +2219,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-07-18T21:18:56+00:00"
+            "time": "2022-12-01T17:03:38+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -2502,16 +2497,16 @@
         },
         {
             "name": "mezzio/mezzio-fastroute",
-            "version": "3.7.0",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-fastroute.git",
-                "reference": "7f952dfb8c9acf8c59b4f2ff854839b74b092d09"
+                "reference": "fb419052c0ac18fd1286d286de6757eceb9f6897"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-fastroute/zipball/7f952dfb8c9acf8c59b4f2ff854839b74b092d09",
-                "reference": "7f952dfb8c9acf8c59b4f2ff854839b74b092d09",
+                "url": "https://api.github.com/repos/mezzio/mezzio-fastroute/zipball/fb419052c0ac18fd1286d286de6757eceb9f6897",
+                "reference": "fb419052c0ac18fd1286d286de6757eceb9f6897",
                 "shasum": ""
             },
             "require": {
@@ -2528,13 +2523,13 @@
                 "zendframework/zend-expressive-fastroute": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-diactoros": "^2.18",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-diactoros": "^2.24",
                 "laminas/laminas-stratigility": "^3.9",
                 "mikey179/vfsstream": "^1.6.11",
-                "phpunit/phpunit": "^9.5.25",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.28"
+                "phpunit/phpunit": "^9.5.27",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "extra": {
@@ -2576,7 +2571,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-10T21:52:43+00:00"
+            "time": "2023-01-09T23:30:41+00:00"
         },
         {
             "name": "mezzio/mezzio-laminasrouter",
@@ -2942,59 +2937,6 @@
             "time": "2022-11-12T15:38:23+00:00"
         },
         {
-            "name": "openlss/lib-array2xml",
-            "version": "1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nullivex/lib-array2xml.git",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "LSS": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Bryan Tong",
-                    "email": "bryan@nullivex.com",
-                    "homepage": "https://www.nullivex.com"
-                },
-                {
-                    "name": "Tony Butler",
-                    "email": "spudz76@gmail.com",
-                    "homepage": "https://www.nullivex.com"
-                }
-            ],
-            "description": "Array2XML conversion library credit to lalit.org",
-            "homepage": "https://www.nullivex.com",
-            "keywords": [
-                "array",
-                "array conversion",
-                "xml",
-                "xml conversion"
-            ],
-            "support": {
-                "issues": "https://github.com/nullivex/lib-array2xml/issues",
-                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
-            },
-            "time": "2019-03-29T20:06:56+00:00"
-        },
-        {
             "name": "phar-io/manifest",
             "version": "2.0.3",
             "source": {
@@ -3316,16 +3258,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.21",
+            "version": "9.2.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0"
+                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
-                "reference": "3f893e19712bb0c8bc86665d1562e9fd509c4ef0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
                 "shasum": ""
             },
             "require": {
@@ -3381,7 +3323,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.21"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
             },
             "funding": [
                 {
@@ -3389,7 +3331,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-14T13:26:54+00:00"
+            "time": "2022-12-28T12:41:10+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4870,6 +4812,70 @@
             "time": "2022-05-25T10:58:12+00:00"
         },
         {
+            "name": "spatie/array-to-xml",
+            "version": "2.17.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/array-to-xml.git",
+                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.2",
+                "pestphp/pest": "^1.21",
+                "phpunit/phpunit": "^9.0",
+                "spatie/pest-plugin-snapshots": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ArrayToXml\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://freek.dev",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Convert an array to xml",
+            "homepage": "https://github.com/spatie/array-to-xml",
+            "keywords": [
+                "array",
+                "convert",
+                "xml"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-12-26T08:22:07+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.1",
             "source": {
@@ -4927,16 +4933,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.16",
+            "version": "v6.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "be294423f337dda97c810733138c0caec1bb0575"
+                "reference": "2ab307342a7233b9a260edd5ef94087aaca57d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/be294423f337dda97c810733138c0caec1bb0575",
-                "reference": "be294423f337dda97c810733138c0caec1bb0575",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2ab307342a7233b9a260edd5ef94087aaca57d18",
+                "reference": "2ab307342a7233b9a260edd5ef94087aaca57d18",
                 "shasum": ""
             },
             "require": {
@@ -5002,7 +5008,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.16"
+                "source": "https://github.com/symfony/console/tree/v6.0.17"
             },
             "funding": [
                 {
@@ -5018,7 +5024,74 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-25T18:58:46+00:00"
+            "time": "2022-12-28T14:21:34+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -5498,21 +5571,22 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.0.2",
+            "version": "v2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66"
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
-                "reference": "d78d39c1599bd1188b8e26bb341da52c3c6d8a66",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
+                "reference": "4b426aac47d6427cc1a1d0f7e2ac724627f5966c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
-                "psr/container": "^2.0"
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -5523,7 +5597,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "2.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5560,7 +5634,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.2"
             },
             "funding": [
                 {
@@ -5576,20 +5650,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-30T19:17:58+00:00"
+            "time": "2022-05-30T19:17:29+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.15",
+            "version": "v6.0.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771"
+                "reference": "3f57003dd8a67ed76870cc03092f8501db7788d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/51ac0fa0ccf132a00519b87c97e8f775fa14e771",
-                "reference": "51ac0fa0ccf132a00519b87c97e8f775fa14e771",
+                "url": "https://api.github.com/repos/symfony/string/zipball/3f57003dd8a67ed76870cc03092f8501db7788d9",
+                "reference": "3f57003dd8a67ed76870cc03092f8501db7788d9",
                 "shasum": ""
             },
             "require": {
@@ -5645,7 +5719,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.15"
+                "source": "https://github.com/symfony/string/tree/v6.0.17"
             },
             "funding": [
                 {
@@ -5661,7 +5735,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-10T09:34:08+00:00"
+            "time": "2022-12-14T15:52:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5715,16 +5789,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.2.0",
+            "version": "5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba"
+                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/fb685a16df3050d4c18d8a4100fe83abe6458cba",
-                "reference": "fb685a16df3050d4c18d8a4100fe83abe6458cba",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
+                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
                 "shasum": ""
             },
             "require": {
@@ -5746,9 +5820,9 @@
                 "fidry/cpu-core-counter": "^0.4.0",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
-                "openlss/lib-array2xml": "^1.0",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
                 "sebastian/diff": "^4.0",
+                "spatie/array-to-xml": "^2.17.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0",
                 "symfony/polyfill-php80": "^1.25"
@@ -5814,9 +5888,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.2.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.4.0"
             },
-            "time": "2022-12-12T08:18:56+00:00"
+            "time": "2022-12-19T21:31:12+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f10c7ab72049b19dfcd6a5894d25d218",
+    "content-hash": "7497964c39f5a70f266cf925754f6c96",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1769,57 +1769,6 @@
             "time": "2022-11-02T16:23:29+00:00"
         },
         {
-            "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3|^7.0|^8.0"
-            },
-            "replace": {
-                "cordoval/hamcrest-php": "*",
-                "davedevelopment/hamcrest-php": "*",
-                "kodova/hamcrest-php": "*"
-            },
-            "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "hamcrest"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "This is the PHP port of Hamcrest Matchers",
-            "keywords": [
-                "test"
-            ],
-            "support": {
-                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
-            },
-            "time": "2020-07-09T08:09:16+00:00"
-        },
-        {
             "name": "laminas/laminas-coding-standard",
             "version": "2.5.0",
             "source": {
@@ -2647,78 +2596,6 @@
                 }
             ],
             "time": "2022-10-10T21:41:26+00:00"
-        },
-        {
-            "name": "mockery/mockery",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mockery/mockery.git",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
-                "shasum": ""
-            },
-            "require": {
-                "hamcrest/hamcrest-php": "^2.0.1",
-                "lib-pcre": ">=7.0",
-                "php": "^7.3 || ^8.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
-                },
-                {
-                    "name": "Dave Marshall",
-                    "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
-                }
-            ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework",
-            "homepage": "https://github.com/mockery/mockery",
-            "keywords": [
-                "BDD",
-                "TDD",
-                "library",
-                "mock",
-                "mock objects",
-                "mockery",
-                "stub",
-                "test",
-                "test double",
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.5.1"
-            },
-            "time": "2022-09-07T15:32:08+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14,6 +14,12 @@
       <code>is_array($methods)</code>
       <code>is_object($item)</code>
     </DocblockTypeContradiction>
+    <MixedAssignment occurrences="1">
+      <code>$serial</code>
+    </MixedAssignment>
+    <MixedOperand occurrences="1">
+      <code>$serial</code>
+    </MixedOperand>
     <RedundantCast occurrences="1">
       <code>(array) $config</code>
     </RedundantCast>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,37 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.1.0@4defa177c89397c5e14737a80fe4896584130674">
+<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
   <file src="src/Application.php">
+    <MixedArgumentTypeCoercion occurrences="1">
+      <code>$middleware</code>
+    </MixedArgumentTypeCoercion>
     <PossiblyInvalidCast occurrences="1">
       <code>$path</code>
     </PossiblyInvalidCast>
   </file>
   <file src="src/Container/ApplicationConfigInjectionDelegator.php">
-    <MissingClosureParamType occurrences="1">
+    <ArgumentTypeCoercion occurrences="1">
+      <code>$name</code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction occurrences="2">
+      <code>is_array($methods)</code>
+      <code>is_array($options)</code>
+    </DocblockTypeContradiction>
+    <InvalidReturnStatement occurrences="1">
       <code>$item</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="6">
-      <code>$config['middleware_pipeline']</code>
-      <code>$name</code>
-      <code>$path</code>
-      <code>$spec['middleware']</code>
-      <code>$spec['middleware']</code>
-      <code>$spec['path']</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$spec['middleware']</code>
-      <code>$spec['path']</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="6">
-      <code>$config</code>
-      <code>$methods</code>
-      <code>$name</code>
-      <code>$path</code>
-      <code>$serial</code>
-      <code>$spec</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="1">
-      <code>$serial</code>
-    </MixedOperand>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>array</code>
+    </InvalidReturnType>
+    <RedundantCast occurrences="1">
+      <code>(array) $config</code>
+    </RedundantCast>
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(array) $config</code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType occurrences="2">
+      <code>is_int($item['priority'])</code>
+      <code>isset($item['priority']) &amp;&amp; is_int($item['priority'])</code>
+    </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType occurrences="1">
+      <code>! is_array($config['routes'])</code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Container/ApplicationFactory.php">
     <MixedArgument occurrences="5">
@@ -71,19 +74,10 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/FilterUsingXForwardedHeadersFactory.php">
-    <MixedArgumentTypeCoercion occurrences="3">
-      <code>$headers</code>
-      <code>$proxies</code>
-      <code>$proxies</code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess occurrences="3">
-      <code>$config[ConfigProvider::DIACTOROS_CONFIG_KEY]</code>
-      <code>$config[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY]</code>
-      <code>$config[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY][ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY]</code>
+    <MixedArrayAccess occurrences="2">
+      <code>$appConfig[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY]</code>
+      <code>$appConfig[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY][ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$config</code>
-    </MixedAssignment>
   </file>
   <file src="src/Container/MiddlewareFactoryFactory.php">
     <MixedArgument occurrences="1">
@@ -195,59 +189,19 @@
     </ParamNameMismatch>
   </file>
   <file src="src/MiddlewareFactory.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>! is_string($middleware)</code>
-    </DocblockTypeContradiction>
-    <MixedArgument occurrences="2">
-      <code>$m</code>
-      <code>$middleware</code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$middleware</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="1">
-      <code>$m</code>
-    </MixedAssignment>
+    <RedundantCondition occurrences="1">
+      <code>isIterable</code>
+    </RedundantCondition>
   </file>
   <file src="src/Response/ServerRequestErrorResponseGenerator.php">
     <PropertyNotSetInConstructor occurrences="1">
       <code>ServerRequestErrorResponseGenerator</code>
     </PropertyNotSetInConstructor>
   </file>
-  <file src="test/ApplicationTest.php">
-    <MissingClosureParamType occurrences="2">
-      <code>$request</code>
-      <code>$response</code>
-    </MissingClosureParamType>
-    <MixedArgument occurrences="2">
-      <code>$data</code>
-      <code>$key</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$data</code>
-      <code>$key</code>
-    </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>iterable</code>
-      <code>iterable</code>
-    </MixedInferredReturnType>
-    <UnusedClosureParam occurrences="3">
-      <code>$req</code>
-      <code>$request</code>
-      <code>$response</code>
-    </UnusedClosureParam>
-  </file>
   <file src="test/ConfigProviderTest.php">
-    <InvalidFunctionCall occurrences="1">
-      <code>$configProvider()</code>
-    </InvalidFunctionCall>
-    <MixedArgument occurrences="2">
-      <code>$configProvider()</code>
+    <MixedArgument occurrences="1">
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="1">
-      <code>$dependencies</code>
-    </MixedArgumentTypeCoercion>
     <MixedArrayAccess occurrences="4">
       <code>$json['packages']</code>
       <code>$package['extra']</code>
@@ -276,16 +230,9 @@
       <code>$middleware</code>
       <code>$pipeline</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="1">
       <code>SplQueue</code>
-      <code>array</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="4">
-      <code>getAllowedMethods</code>
-      <code>getAllowedMethods</code>
-      <code>getMiddleware</code>
-      <code>getPath</code>
-    </MixedMethodCall>
     <MixedReturnStatement occurrences="1">
       <code>$r-&gt;getValue($pipeline)</code>
     </MixedReturnStatement>
@@ -435,18 +382,11 @@
     </InvalidArgument>
   </file>
   <file src="test/MiddlewareFactoryTest.php">
-    <MissingClosureParamType occurrences="8">
+    <MissingClosureParamType occurrences="2">
       <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$request</code>
-      <code>$request</code>
-      <code>$request</code>
       <code>$request</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="4">
-      <code>$middleware</code>
+    <MixedArgument occurrences="3">
       <code>$r-&gt;getValue($pipeline)</code>
       <code>$r-&gt;getValue($pipeline)</code>
       <code>$received[0]</code>
@@ -454,17 +394,8 @@
     <MixedAssignment occurrences="1">
       <code>$received</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
-      <code>iterable</code>
-    </MixedInferredReturnType>
-    <UnusedClosureParam occurrences="8">
+    <UnusedClosureParam occurrences="2">
       <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$request</code>
-      <code>$request</code>
-      <code>$request</code>
       <code>$request</code>
     </UnusedClosureParam>
   </file>
@@ -481,7 +412,7 @@
     <InvalidStringClass occurrences="1">
       <code>new $adapter()</code>
     </InvalidStringClass>
-    <MissingClosureParamType occurrences="19">
+    <MissingClosureParamType occurrences="16">
       <code>$handler</code>
       <code>$handler</code>
       <code>$handler</code>
@@ -490,7 +421,6 @@
       <code>$handler</code>
       <code>$handler</code>
       <code>$handler</code>
-      <code>$next</code>
       <code>$req</code>
       <code>$req</code>
       <code>$req</code>
@@ -499,27 +429,9 @@
       <code>$req</code>
       <code>$req</code>
       <code>$req</code>
-      <code>$req</code>
-      <code>$res</code>
     </MissingClosureParamType>
-    <MixedArgumentTypeCoercion occurrences="6">
-      <code>$this-&gt;responseFactory</code>
-      <code>$this-&gt;responseFactory</code>
-      <code>$this-&gt;responseFactory</code>
-      <code>$this-&gt;responseFactory</code>
-      <code>$this-&gt;responseFactory</code>
-      <code>$this-&gt;responseFactory</code>
-    </MixedArgumentTypeCoercion>
-    <MixedInferredReturnType occurrences="2">
-      <code>ResponseInterface</code>
-    </MixedInferredReturnType>
-    <MixedMethodCall occurrences="1">
-      <code>withBody</code>
-    </MixedMethodCall>
-    <MixedReturnStatement occurrences="1">
-      <code>$res-&gt;withBody($stream)</code>
-    </MixedReturnStatement>
-    <UnusedClosureParam occurrences="18">
+    <MixedInferredReturnType occurrences="1"/>
+    <UnusedClosureParam occurrences="17">
       <code>$handler</code>
       <code>$handler</code>
       <code>$handler</code>
@@ -528,7 +440,6 @@
       <code>$handler</code>
       <code>$handler</code>
       <code>$handler</code>
-      <code>$next</code>
       <code>$req</code>
       <code>$req</code>
       <code>$req</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -14,7 +14,11 @@
       <code>is_array($methods)</code>
       <code>is_object($item)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="1">
+    <MixedArgument occurrences="1">
+      <code>$name</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$name</code>
       <code>$serial</code>
     </MixedAssignment>
     <MixedOperand occurrences="1">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,26 +9,19 @@
     </PossiblyInvalidCast>
   </file>
   <file src="src/Container/ApplicationConfigInjectionDelegator.php">
-    <ArgumentTypeCoercion occurrences="1">
-      <code>$name</code>
-    </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction occurrences="3">
+      <code>! is_array($item)</code>
       <code>is_array($methods)</code>
-      <code>is_array($options)</code>
+      <code>is_object($item)</code>
     </DocblockTypeContradiction>
-    <InvalidReturnStatement occurrences="1">
-      <code>$item</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array</code>
-    </InvalidReturnType>
     <RedundantCast occurrences="1">
       <code>(array) $config</code>
     </RedundantCast>
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(array) $config</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="3">
+      <code>gettype($item)</code>
       <code>is_int($item['priority'])</code>
       <code>isset($item['priority']) &amp;&amp; is_int($item['priority'])</code>
     </RedundantConditionGivenDocblockType>

--- a/src/Application.php
+++ b/src/Application.php
@@ -14,6 +14,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 use function Laminas\Stratigility\path;
 
+/** @psalm-import-type MiddlewareParam from MiddlewareFactory */
 class Application implements MiddlewareInterface, RequestHandlerInterface
 {
     public function __construct(
@@ -63,12 +64,14 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
      *
      * The resulting middleware, in both cases, is piped to the pipeline.
      *
-     * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middlewareOrPath
+     * @param non-empty-string|array|callable|MiddlewareInterface|RequestHandlerInterface $middlewareOrPath
      *     Either the middleware to pipe, or the path to segregate the $middleware
      *     by, via a PathMiddlewareDecorator.
-     * @param null|string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
+     * @param null|non-empty-string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     If present, middleware or request handler to segregate by the path
      *     specified in $middlewareOrPath.
+     * @psalm-param non-empty-string|MiddlewareParam $middlewareOrPath
+     * @psalm-param null|MiddlewareParam $middleware
      */
     public function pipe($middlewareOrPath, $middleware = null): void
     {
@@ -85,11 +88,12 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     /**
      * Add a route for the route middleware to match.
      *
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|array $methods HTTP method to accept; null indicates any.
-     * @param null|string $name The name of the route.
+     * @param null|list<string> $methods HTTP method to accept; null indicates any.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function route(string $path, $middleware, ?array $methods = null, ?string $name = null): Router\Route
     {
@@ -102,10 +106,11 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     }
 
     /**
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|string $name The name of the route.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function get(string $path, $middleware, ?string $name = null): Router\Route
     {
@@ -113,10 +118,11 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     }
 
     /**
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|string $name The name of the route.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function post(string $path, $middleware, $name = null): Router\Route
     {
@@ -124,10 +130,11 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     }
 
     /**
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|string $name The name of the route.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function put(string $path, $middleware, ?string $name = null): Router\Route
     {
@@ -135,10 +142,11 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     }
 
     /**
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|string $name The name of the route.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function patch(string $path, $middleware, ?string $name = null): Router\Route
     {
@@ -146,10 +154,11 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     }
 
     /**
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|string $name The name of the route.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function delete(string $path, $middleware, ?string $name = null): Router\Route
     {
@@ -157,10 +166,11 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     }
 
     /**
+     * @param non-empty-string $path
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     Middleware or request handler (or service name resolving to one of
      *     those types) to associate with route.
-     * @param null|string $name The name of the route.
+     * @param null|non-empty-string $name The name of the route.
      */
     public function any(string $path, $middleware, ?string $name = null): Router\Route
     {
@@ -170,7 +180,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     /**
      * Retrieve all directly registered routes with the application.
      *
-     * @return Router\Route[]
+     * @return list<Router\Route>
      */
     public function getRoutes(): array
     {

--- a/src/Application.php
+++ b/src/Application.php
@@ -64,13 +64,13 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
      *
      * The resulting middleware, in both cases, is piped to the pipeline.
      *
-     * @param non-empty-string|array|callable|MiddlewareInterface|RequestHandlerInterface $middlewareOrPath
+     * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middlewareOrPath
      *     Either the middleware to pipe, or the path to segregate the $middleware
      *     by, via a PathMiddlewareDecorator.
-     * @param null|non-empty-string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
+     * @param null|string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
      *     If present, middleware or request handler to segregate by the path
      *     specified in $middlewareOrPath.
-     * @psalm-param non-empty-string|MiddlewareParam $middlewareOrPath
+     * @psalm-param string|MiddlewareParam $middlewareOrPath
      * @psalm-param null|MiddlewareParam $middleware
      */
     public function pipe($middlewareOrPath, $middleware = null): void

--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -260,7 +260,7 @@ class ApplicationConfigInjectionDelegator
      * If the 'middleware' value is missing, or not viable as middleware, it
      * raises an exception, to ensure the pipeline is built correctly.
      *
-     * @return callable(mixed): MiddlewareSpec
+     * @return callable(MiddlewareSpec): MiddlewareSpec
      * @throws InvalidArgumentException
      */
     private static function createCollectionMapper(): callable

--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -14,7 +14,6 @@ use SplPriorityQueue;
 use function array_key_exists;
 use function array_map;
 use function array_reduce;
-use function assert;
 use function gettype;
 use function is_array;
 use function is_int;
@@ -225,8 +224,7 @@ class ApplicationConfigInjectionDelegator
                 }
             }
 
-            $name = $spec['name'] ?? (is_string($key) ? $key : null);
-            assert(is_string($name) && $name !== '');
+            $name  = $spec['name'] ?? (is_string($key) ? $key : null);
             $route = $application->route(
                 $spec['path'],
                 $spec['middleware'],

--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -300,7 +300,6 @@ class ApplicationConfigInjectionDelegator
             $priority = isset($item['priority']) && is_int($item['priority'])
                 ? $item['priority']
                 : 1;
-            /** @psalm-var int $serial */
             $queue->insert($item, [$priority, $serial]);
             $serial -= 1;
             return $queue;

--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -14,6 +14,7 @@ use SplPriorityQueue;
 use function array_key_exists;
 use function array_map;
 use function array_reduce;
+use function assert;
 use function gettype;
 use function is_array;
 use function is_int;
@@ -31,11 +32,13 @@ use const PHP_INT_MAX;
  *     allowed_methods?: list<string>,
  *     name?: null|non-empty-string,
  *     options?: array<string, mixed>,
+ *     ...
  * }
  * @psalm-type MiddlewareSpec = array{
  *     middleware: MiddlewareParam,
  *     path?: non-empty-string,
  *     priority?: int,
+ *     ...
  * }
  */
 class ApplicationConfigInjectionDelegator
@@ -222,7 +225,8 @@ class ApplicationConfigInjectionDelegator
                 }
             }
 
-            $name  = $spec['name'] ?? (is_string($key) ? $key : null);
+            $name = $spec['name'] ?? (is_string($key) ? $key : null);
+            assert(is_string($name) && $name !== '');
             $route = $application->route(
                 $spec['path'],
                 $spec['middleware'],

--- a/src/MiddlewareFactory.php
+++ b/src/MiddlewareFactory.php
@@ -7,6 +7,8 @@ namespace Mezzio;
 use Laminas\Stratigility\Middleware\CallableMiddlewareDecorator;
 use Laminas\Stratigility\Middleware\RequestHandlerMiddleware;
 use Laminas\Stratigility\MiddlewarePipe;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Webmozart\Assert\Assert;
@@ -42,6 +44,10 @@ use function is_string;
  *   factory instance, as a LazyLoadingMiddleware instance.
  * - pipeline() will create a MiddlewarePipe instance from the array of
  *   middleware passed to it, after passing each first to prepare().
+ *
+ * @psalm-type InterfaceType = RequestHandlerInterface|RequestHandlerMiddleware|MiddlewareInterface
+ * @psalm-type CallableType = callable(ServerRequestInterface, RequestHandlerInterface): ResponseInterface
+ * @psalm-type MiddlewareParam = string|InterfaceType|CallableType|list<string|InterfaceType|CallableType>
  */
 class MiddlewareFactory
 {
@@ -51,6 +57,7 @@ class MiddlewareFactory
 
     /**
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface $middleware
+     * @psalm-param MiddlewareParam $middleware
      * @throws Exception\InvalidMiddlewareException If argument is not one of
      *    the specified types.
      */
@@ -116,6 +123,7 @@ class MiddlewareFactory
      * MiddlewarePipe instance the method returns.
      *
      * @param string|array|callable|MiddlewareInterface|RequestHandlerInterface ...$middleware
+     * @psalm-param MiddlewareParam ...$middleware
      */
     public function pipeline(...$middleware): MiddlewarePipe
     {

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -7,6 +7,7 @@ namespace MezzioTest;
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
 use Laminas\ServiceManager\Config;
+use Laminas\ServiceManager\ConfigInterface;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stratigility\Middleware\ErrorHandler;
 use Mezzio\Application;
@@ -35,6 +36,7 @@ use const Mezzio\IMPLICIT_OPTIONS_MIDDLEWARE;
 use const Mezzio\NOT_FOUND_MIDDLEWARE;
 use const Mezzio\ROUTE_MIDDLEWARE;
 
+/** @psalm-import-type ServiceManagerConfigurationType from ConfigInterface */
 class ConfigProviderTest extends TestCase
 {
     private ConfigProvider $provider;
@@ -48,40 +50,40 @@ class ConfigProviderTest extends TestCase
     {
         $aliases = $this->provider->getDependencies()['aliases'] ?? [];
 
-        $this->assertArrayHasKey(DEFAULT_DELEGATE, $aliases);
-        $this->assertArrayHasKey(DISPATCH_MIDDLEWARE, $aliases);
-        $this->assertArrayHasKey(IMPLICIT_HEAD_MIDDLEWARE, $aliases);
-        $this->assertArrayHasKey(IMPLICIT_OPTIONS_MIDDLEWARE, $aliases);
-        $this->assertArrayHasKey(NOT_FOUND_MIDDLEWARE, $aliases);
-        $this->assertArrayHasKey(ROUTE_MIDDLEWARE, $aliases);
+        self::assertArrayHasKey(DEFAULT_DELEGATE, $aliases);
+        self::assertArrayHasKey(DISPATCH_MIDDLEWARE, $aliases);
+        self::assertArrayHasKey(IMPLICIT_HEAD_MIDDLEWARE, $aliases);
+        self::assertArrayHasKey(IMPLICIT_OPTIONS_MIDDLEWARE, $aliases);
+        self::assertArrayHasKey(NOT_FOUND_MIDDLEWARE, $aliases);
+        self::assertArrayHasKey(ROUTE_MIDDLEWARE, $aliases);
     }
 
     public function testProviderDefinesExpectedFactoryServices(): void
     {
         $factories = $this->provider->getDependencies()['factories'] ?? [];
 
-        $this->assertArrayHasKey(Application::class, $factories);
-        $this->assertArrayHasKey(ApplicationPipeline::class, $factories);
-        $this->assertArrayHasKey(EmitterInterface::class, $factories);
-        $this->assertArrayHasKey(ErrorHandler::class, $factories);
-        $this->assertArrayHasKey(MiddlewareContainer::class, $factories);
-        $this->assertArrayHasKey(MiddlewareFactory::class, $factories);
-        $this->assertArrayHasKey(Middleware\ErrorResponseGenerator::class, $factories);
-        $this->assertArrayHasKey(NotFoundHandler::class, $factories);
-        $this->assertArrayHasKey(RequestHandlerRunner::class, $factories);
-        $this->assertArrayHasKey(ResponseInterface::class, $factories);
-        $this->assertArrayHasKey(ServerRequestInterface::class, $factories);
-        $this->assertArrayHasKey(ServerRequestErrorResponseGenerator::class, $factories);
-        $this->assertArrayHasKey(StreamInterface::class, $factories);
+        self::assertArrayHasKey(Application::class, $factories);
+        self::assertArrayHasKey(ApplicationPipeline::class, $factories);
+        self::assertArrayHasKey(EmitterInterface::class, $factories);
+        self::assertArrayHasKey(ErrorHandler::class, $factories);
+        self::assertArrayHasKey(MiddlewareContainer::class, $factories);
+        self::assertArrayHasKey(MiddlewareFactory::class, $factories);
+        self::assertArrayHasKey(Middleware\ErrorResponseGenerator::class, $factories);
+        self::assertArrayHasKey(NotFoundHandler::class, $factories);
+        self::assertArrayHasKey(RequestHandlerRunner::class, $factories);
+        self::assertArrayHasKey(ResponseInterface::class, $factories);
+        self::assertArrayHasKey(ServerRequestInterface::class, $factories);
+        self::assertArrayHasKey(ServerRequestErrorResponseGenerator::class, $factories);
+        self::assertArrayHasKey(StreamInterface::class, $factories);
     }
 
     public function testInvocationReturnsArrayWithDependencies(): void
     {
         $config = ($this->provider)();
-        $this->assertIsArray($config);
-        $this->assertArrayHasKey('dependencies', $config);
-        $this->assertArrayHasKey('aliases', $config['dependencies']);
-        $this->assertArrayHasKey('factories', $config['dependencies']);
+        self::assertIsArray($config);
+        self::assertArrayHasKey('dependencies', $config);
+        self::assertArrayHasKey('aliases', $config['dependencies']);
+        self::assertArrayHasKey('factories', $config['dependencies']);
     }
 
     public function testServicesDefinedInConfigProvider(): void
@@ -95,7 +97,10 @@ class ConfigProviderTest extends TestCase
         foreach ($json['packages'] as $package) {
             if (isset($package['extra']['laminas']['config-provider'])) {
                 $configProvider = new $package['extra']['laminas']['config-provider']();
-                $config         = array_merge_recursive($config, $configProvider());
+                self::assertIsCallable($configProvider);
+                $value = $configProvider();
+                self::assertIsArray($value);
+                $config = array_merge_recursive($config, $value);
             }
         }
 
@@ -105,26 +110,29 @@ class ConfigProviderTest extends TestCase
 
         $dependencies = $this->provider->getDependencies();
         foreach ($dependencies['factories'] ?? [] as $name => $factory) {
-            $this->assertIsString($factory);
-            $this->assertTrue($container->has($name), sprintf('Container does not contain service %s', $name));
-            $this->assertIsObject(
+            self::assertIsString($factory);
+            self::assertTrue($container->has($name), sprintf('Container does not contain service %s', $name));
+            self::assertIsObject(
                 $container->get($name),
                 sprintf('Cannot get service %s from container using factory %s', $name, $factory)
             );
         }
 
         foreach ($dependencies['aliases'] ?? [] as $alias => $dependency) {
-            $this->assertTrue(
+            self::assertIsString($alias);
+            self::assertIsString($dependency);
+            self::assertTrue(
                 $container->has($alias),
                 sprintf('Container does not contain service with alias %s', $alias)
             );
-            $this->assertIsObject(
+            self::assertIsObject(
                 $container->get($alias),
                 sprintf('Cannot get service %s using alias %s', $dependency, $alias)
             );
         }
     }
 
+    /** @psalm-param ServiceManagerConfigurationType $dependencies */
     private function getContainer(array $dependencies): ServiceManager
     {
         $container = new ServiceManager();

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -28,6 +28,10 @@ use SplQueue;
 use function array_reduce;
 use function array_shift;
 
+/**
+ * @psalm-import-type MiddlewareParam from MiddlewareFactory
+ * @psalm-import-type RouteSpec from ApplicationConfigInjectionDelegator
+ */
 class ApplicationConfigInjectionDelegatorTest extends TestCase
 {
     private InMemoryContainer $container;
@@ -70,12 +74,13 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
     }
 
     /**
-     * @param (array|callable|string)[] $spec
+     * @psalm-param RouteSpec $spec
+     * @psalm-param list<Route> $routes
      */
     public static function assertRoute(array $spec, array $routes): void
     {
         Assert::assertThat(
-            array_reduce($routes, static function ($found, $route) use ($spec) {
+            array_reduce($routes, static function ($found, Route $route) use ($spec) {
                 if ($found) {
                     return $found;
                 }
@@ -122,6 +127,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
         Assert::assertThat($found, Assert::isTrue(), $message);
     }
 
+    /** @return list<array{MiddlewareParam}> */
     public function callableMiddlewares(): array
     {
         return [
@@ -148,7 +154,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
 
     /**
      * @dataProvider callableMiddlewares
-     * @param callable|array|string $middleware
+     * @param MiddlewareParam $middleware
      */
     public function testInjectRoutesFromConfigSetsUpRoutesFromConfig($middleware): void
     {
@@ -196,6 +202,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
 
         $app = $this->createApplication();
 
+        /** @psalm-suppress InvalidArgument */
         ApplicationConfigInjectionDelegator::injectRoutesFromConfig($app, $config);
 
         $routes = $app->getRoutes();
@@ -279,6 +286,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Allowed HTTP methods');
+        /** @psalm-suppress InvalidArgument */
         ApplicationConfigInjectionDelegator::injectRoutesFromConfig($app, $config);
     }
 
@@ -299,6 +307,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Route options must be an array');
+        /** @psalm-suppress InvalidArgument */
         ApplicationConfigInjectionDelegator::injectRoutesFromConfig($app, $config);
     }
 
@@ -423,6 +432,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid pipeline specification received');
+        /** @psalm-suppress InvalidArgument */
         ApplicationConfigInjectionDelegator::injectPipelineFromConfig($app, $config);
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

Now `mezzio-router` has more precise types, the next renovate PR will have a bunch of failures. This patch deals with the improved upstream types and makes some further improvements here with a decent baseline reduction and better type coverage.
