### PR TITLE
Correct references to core Twig classes in the Twig templating documentation

### DIFF
--- a/docs/book/v3/features/template/twig.md
+++ b/docs/book/v3/features/template/twig.md
@@ -33,13 +33,11 @@ Alternately, you can instantiate and configure the engine yourself, and pass it
 to the `Mezzio\Twig\TwigRenderer` constructor:
 
 ```php
-use Twig_Environment;
-use Twig_Loader_Array;
 use Mezzio\Twig\TwigRenderer;
 
 // Create the engine instance:
-$loader = new Twig_Loader_Array(include 'config/templates.php');
-$twig = new Twig_Environment($loader);
+$loader = new Twig\Loader\ArrayLoader(include 'config/templates.php');
+$twig = new Twig\Environment($loader);
 
 // Configure it:
 $twig->addExtension(new CustomExtension());

--- a/docs/book/v3/features/template/twig.md
+++ b/docs/book/v3/features/template/twig.md
@@ -34,10 +34,12 @@ to the `Mezzio\Twig\TwigRenderer` constructor:
 
 ```php
 use Mezzio\Twig\TwigRenderer;
+use Twig\Loader\ArrayLoader;
+use Twig\Environment;
 
 // Create the engine instance:
-$loader = new Twig\Loader\ArrayLoader(include 'config/templates.php');
-$twig = new Twig\Environment($loader);
+$loader = new ArrayLoader(include 'config/templates.php');
+$twig = new Environment($loader);
 
 // Configure it:
 $twig->addExtension(new CustomExtension());


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

While using the package, recently, I found that the documentation doesn't match up with the referenced namespaces two twig classes referenced in the documentation. Given that, this change has been created to address that, bringing the documentation in line with the current state of the code.
