### PR TITLE
Drop support for PHP 8.0, Upgrade PHPUnit to ^10

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 /psalm-baseline.xml export-ignore
 /phpcs.xml export-ignore
 /phpunit.xml.dist export-ignore
+.psr-container.php.stub export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
-/.phpunit.result.cache
+/.phpunit.cache
 /.phpcs-cache

--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container {
+    /**
+     * Provides automatic type inference for Psalm when retrieving a service from a container using a FQCN
+     */
+    interface ContainerInterface
+    {
+        /**
+         * @param string|class-string $id
+         * @return bool
+         */
+        public function has(string $id);
+
+        /**
+         * @template T
+         * @psalm-param string|class-string<T> $id
+         * @psalm-return ($id is class-string ? T : mixed)
+         */
+        public function get(string $id);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
             "composer/package-versions-deprecated": true
         },
         "platform": {
-            "php": "8.0.99"
+            "php": "8.1.99"
         }
     },
     "extra": {
@@ -37,7 +37,7 @@
         }
     },
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^2.1",
         "laminas/laminas-stratigility": "^3.5",
@@ -57,9 +57,9 @@
         "mezzio/mezzio-aurarouter": "^3.6",
         "mezzio/mezzio-fastroute": "^3.8",
         "mezzio/mezzio-laminasrouter": "^3.7",
-        "phpunit/phpunit": "^9.5.27",
+        "phpunit/phpunit": "^9.6.3",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.4"
+        "vimeo/psalm": "^5.7.7"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "mezzio/mezzio-aurarouter": "^3.6",
         "mezzio/mezzio-fastroute": "^3.8",
         "mezzio/mezzio-laminasrouter": "^3.7",
-        "phpunit/phpunit": "^9.6.3",
+        "phpunit/phpunit": "^10.0.11",
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.7.7"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "320fd874268c7ab0f64cbeb70d9c8113",
+    "content-hash": "6afb84be518f2c51e2a910101d2b3ddb",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1464,76 +1464,6 @@
                 "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
             },
             "time": "2019-12-04T15:06:13+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -3135,16 +3065,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.25",
+            "version": "10.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "0e2b40518197a8c0d4b08bc34dfff1c99c508954"
+                "reference": "b9c21a93dd8c8eed79879374884ee733259475cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0e2b40518197a8c0d4b08bc34dfff1c99c508954",
-                "reference": "0e2b40518197a8c0d4b08bc34dfff1c99c508954",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b9c21a93dd8c8eed79879374884ee733259475cc",
+                "reference": "b9c21a93dd8c8eed79879374884ee733259475cc",
                 "shasum": ""
             },
             "require": {
@@ -3152,18 +3082,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^3.0",
+                "sebastian/complexity": "^3.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/lines-of-code": "^2.0",
+                "sebastian/version": "^4.0",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcov": "*",
@@ -3172,7 +3102,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -3200,7 +3130,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.25"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.1"
             },
             "funding": [
                 {
@@ -3208,32 +3138,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-25T05:32:00+00:00"
+            "time": "2023-02-25T05:35:03+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3260,7 +3190,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3268,28 +3198,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2023-02-10T16:53:14+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -3297,7 +3227,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3323,7 +3253,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
             },
             "funding": [
                 {
@@ -3331,32 +3261,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2023-02-03T06:56:09+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3382,7 +3312,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3390,32 +3320,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2023-02-03T06:56:46+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3441,7 +3371,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
             "funding": [
                 {
@@ -3449,24 +3379,23 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.3",
+            "version": "10.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555"
+                "reference": "87d5cfdb4ecf440fb9f08b636b1152be433fc6f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e7b1615e3e887d6c719121c6d4a44b0ab9645555",
-                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/87d5cfdb4ecf440fb9f08b636b1152be433fc6f1",
+                "reference": "87d5cfdb4ecf440fb9f08b636b1152be433fc6f1",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -3476,27 +3405,26 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-file-iterator": "^4.0",
+                "phpunit/php-invoker": "^4.0",
+                "phpunit/php-text-template": "^3.0",
+                "phpunit/php-timer": "^6.0",
+                "sebastian/cli-parser": "^2.0",
+                "sebastian/code-unit": "^2.0",
+                "sebastian/comparator": "^5.0",
+                "sebastian/diff": "^5.0",
+                "sebastian/environment": "^6.0",
+                "sebastian/exporter": "^5.0",
+                "sebastian/global-state": "^6.0",
+                "sebastian/object-enumerator": "^5.0",
+                "sebastian/recursion-context": "^5.0",
+                "sebastian/type": "^4.0",
+                "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "*"
             },
             "bin": [
                 "phpunit"
@@ -3504,7 +3432,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "10.0-dev"
                 }
             },
             "autoload": {
@@ -3535,7 +3463,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.3"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.12"
             },
             "funding": [
                 {
@@ -3551,7 +3479,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-04T13:37:15+00:00"
+            "time": "2023-02-25T06:05:15+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3665,28 +3593,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3709,7 +3637,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3717,32 +3645,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2023-02-03T06:58:15+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3765,7 +3693,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
             },
             "funding": [
                 {
@@ -3773,32 +3701,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2023-02-03T06:58:43+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3820,7 +3748,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3828,34 +3756,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3894,7 +3824,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -3902,33 +3832,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2023-02-03T07:07:16+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3951,7 +3881,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
             },
             "funding": [
                 {
@@ -3959,33 +3889,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-02-03T06:59:47+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
+                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^10.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4017,7 +3947,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4025,27 +3955,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-02-03T07:00:31+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -4053,7 +3983,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4072,7 +4002,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -4080,7 +4010,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4088,34 +4018,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2023-02-03T07:03:04+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4157,7 +4087,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4165,38 +4095,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2023-02-03T07:06:49+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
+                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -4221,7 +4148,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
             },
             "funding": [
                 {
@@ -4229,33 +4156,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-02-03T07:07:38+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
+                "nikic/php-parser": "^4.10",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -4278,7 +4205,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
             },
             "funding": [
                 {
@@ -4286,34 +4213,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-02-03T07:08:02+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4335,7 +4262,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4343,32 +4270,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4390,7 +4317,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
             },
             "funding": [
                 {
@@ -4398,32 +4325,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
+                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -4453,7 +4380,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
             },
             "funding": [
                 {
@@ -4461,87 +4388,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2023-02-03T07:05:40+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4564,7 +4436,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
             },
             "funding": [
                 {
@@ -4572,29 +4444,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4617,7 +4489,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
             },
             "funding": [
                 {
@@ -4625,7 +4497,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "slevomat/coding-standard",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7497964c39f5a70f266cf925754f6c96",
+    "content-hash": "320fd874268c7ab0f64cbeb70d9c8113",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1467,30 +1467,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1517,7 +1517,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -1533,7 +1533,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1638,16 +1638,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "0.4.1",
+            "version": "0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2"
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/79261cc280aded96d098e1b0e0ba0c4881b432c2",
-                "reference": "79261cc280aded96d098e1b0e0ba0c4881b432c2",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
+                "reference": "b58e5a3933e541dc286cc91fc4f3898bbc6f1623",
                 "shasum": ""
             },
             "require": {
@@ -1687,7 +1687,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.4.1"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/0.5.1"
             },
             "funding": [
                 {
@@ -1695,7 +1695,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-16T22:01:02+00:00"
+            "time": "2022-12-24T12:35:10+00:00"
         },
         {
             "name": "filp/whoops",
@@ -2289,16 +2289,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.29.0",
+            "version": "2.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850"
+                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
-                "reference": "e40ee8d86cc1907083e273bfd6ed8b6dde2d9850",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
+                "reference": "b7d217b5e4951955fda9a3a5ada91b717b5c8d5c",
                 "shasum": ""
             },
             "require": {
@@ -2370,7 +2370,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-13T22:53:38+00:00"
+            "time": "2023-01-30T22:41:19+00:00"
         },
         {
             "name": "mezzio/mezzio-aurarouter",
@@ -3135,23 +3135,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.23",
+            "version": "9.2.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c"
+                "reference": "0e2b40518197a8c0d4b08bc34dfff1c99c508954"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
-                "reference": "9f1f0f9a2fbb680b26d1cf9b61b6eac43a6e4e9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/0e2b40518197a8c0d4b08bc34dfff1c99c508954",
+                "reference": "0e2b40518197a8c0d4b08bc34dfff1c99c508954",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3200,7 +3200,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.23"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.25"
             },
             "funding": [
                 {
@@ -3208,7 +3208,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-28T12:41:10+00:00"
+            "time": "2023-02-25T05:32:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3453,16 +3453,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.28",
+            "version": "9.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e"
+                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/954ca3113a03bf780d22f07bf055d883ee04b65e",
-                "reference": "954ca3113a03bf780d22f07bf055d883ee04b65e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e7b1615e3e887d6c719121c6d4a44b0ab9645555",
+                "reference": "e7b1615e3e887d6c719121c6d4a44b0ab9645555",
                 "shasum": ""
             },
             "require": {
@@ -3504,7 +3504,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -3535,7 +3535,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.28"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.3"
             },
             "funding": [
                 {
@@ -3551,7 +3551,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-14T12:32:24+00:00"
+            "time": "2023-02-04T13:37:15+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4029,16 +4029,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -4080,7 +4080,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -4088,7 +4088,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4402,16 +4402,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -4450,10 +4450,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -4461,7 +4461,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -4520,16 +4520,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -4564,7 +4564,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -4572,7 +4572,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4690,26 +4690,25 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "2.17.1",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46"
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
-                "reference": "5cbec9c6ab17e320c58a259f0cebe88bde4a7c46",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
-                "php": "^7.4|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.2",
                 "pestphp/pest": "^1.21",
-                "phpunit/phpunit": "^9.0",
                 "spatie/pest-plugin-snapshots": "^1.1"
             },
             "type": "library",
@@ -4738,7 +4737,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/2.17.1"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
             },
             "funding": [
                 {
@@ -4750,20 +4749,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-26T08:22:07+00:00"
+            "time": "2022-12-24T13:43:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -4799,31 +4798,33 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.0.17",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2ab307342a7233b9a260edd5ef94087aaca57d18"
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2ab307342a7233b9a260edd5ef94087aaca57d18",
-                "reference": "2ab307342a7233b9a260edd5ef94087aaca57d18",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3e294254f2191762c1d137aed4b94e966965e985",
+                "reference": "3e294254f2191762c1d137aed4b94e966965e985",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^1.1|^2|^3",
                 "symfony/string": "^5.4|^6.0"
@@ -4885,7 +4886,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.0.17"
+                "source": "https://github.com/symfony/console/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -4901,29 +4902,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-28T14:21:34+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/1ee04c65529dea5d8744774d474e7cbd2f1206d3",
+                "reference": "1ee04c65529dea5d8744774d474e7cbd2f1206d3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.3-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4952,7 +4953,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.0"
             },
             "funding": [
                 {
@@ -4968,24 +4969,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2022-11-25T10:21:52+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.13",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79"
+                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/3adca49133bd055ebe6011ed1e012be3c908af79",
-                "reference": "3adca49133bd055ebe6011ed1e012be3c908af79",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e59e8a4006afd7f5654786a83b4fcb8da98f4593",
+                "reference": "e59e8a4006afd7f5654786a83b4fcb8da98f4593",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
@@ -5015,7 +5016,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.13"
+                "source": "https://github.com/symfony/filesystem/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -5031,7 +5032,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-21T20:25:27+00:00"
+            "time": "2023-01-20T17:45:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5364,89 +5365,6 @@
             "time": "2022-11-03T14:55:06+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.27-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-11-03T14:55:06+00:00"
-        },
-        {
             "name": "symfony/service-contracts",
             "version": "v2.5.2",
             "source": {
@@ -5531,20 +5449,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.17",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "3f57003dd8a67ed76870cc03092f8501db7788d9"
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/3f57003dd8a67ed76870cc03092f8501db7788d9",
-                "reference": "3f57003dd8a67ed76870cc03092f8501db7788d9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
+                "reference": "b2dac0fa27b1ac0f9c0c0b23b43977f12308d0b0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -5556,6 +5474,7 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
+                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -5596,7 +5515,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.17"
+                "source": "https://github.com/symfony/string/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -5612,7 +5531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-14T15:52:41+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5666,16 +5585,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.4.0",
+            "version": "5.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863"
+                "reference": "e028ba46ba0d7f9a78bc3201c251e137383e145f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
-                "reference": "62db5d4f6a7ae0a20f7cc5a4952d730272fc0863",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e028ba46ba0d7f9a78bc3201c251e137383e145f",
+                "reference": "e028ba46ba0d7f9a78bc3201c251e137383e145f",
                 "shasum": ""
             },
             "require": {
@@ -5694,28 +5613,27 @@
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.2",
-                "fidry/cpu-core-counter": "^0.4.0",
+                "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
                 "nikic/php-parser": "^4.13",
                 "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
-                "sebastian/diff": "^4.0",
-                "spatie/array-to-xml": "^2.17.0",
+                "sebastian/diff": "^4.0 || ^5.0",
+                "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/polyfill-php80": "^1.25"
+                "symfony/filesystem": "^5.4 || ^6.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4",
-                "brianium/paratest": "^6.0",
+                "brianium/paratest": "^6.9",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/phpdoc-parser": "^1.6",
-                "phpunit/phpunit": "^9.5",
+                "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
@@ -5761,13 +5679,14 @@
             "keywords": [
                 "code",
                 "inspection",
-                "php"
+                "php",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.4.0"
+                "source": "https://github.com/vimeo/psalm/tree/5.7.7"
             },
-            "time": "2022-12-19T21:31:12+00:00"
+            "time": "2023-02-25T01:05:07+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -5831,11 +5750,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.0.99"
+        "php": "8.1.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,24 +2,31 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="mezzio-response-factory">
-            <file>./test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php</file>
-            <file>./test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php</file>
-            <file>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</file>
-        </testsuite>
-        <testsuite name="mezzio">
-            <directory>./test</directory>
-            <exclude>./test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php</exclude>
-            <exclude>./test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php</exclude>
-            <exclude>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</exclude>
-        </testsuite>
-    </testsuites>
-
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         displayDetailsOnIncompleteTests="true"
+         displayDetailsOnSkippedTests="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+>
+  <testsuites>
+    <testsuite name="mezzio-response-factory">
+      <file>./test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php</file>
+      <file>./test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php</file>
+      <file>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</file>
+    </testsuite>
+    <testsuite name="mezzio">
+      <directory>./test</directory>
+      <exclude>./test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php</exclude>
+      <exclude>./test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php</exclude>
+      <exclude>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</exclude>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,75 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.7.7@e028ba46ba0d7f9a78bc3201c251e137383e145f">
   <file src="src/Application.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>$middleware</code>
     </MixedArgumentTypeCoercion>
-    <PossiblyInvalidCast occurrences="1">
-      <code>$path</code>
-    </PossiblyInvalidCast>
   </file>
   <file src="src/Container/ApplicationConfigInjectionDelegator.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>! is_array($item)</code>
       <code>is_array($methods)</code>
       <code>is_object($item)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$name</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$name</code>
       <code>$serial</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$serial</code>
     </MixedOperand>
-    <RedundantCast occurrences="1">
-      <code>(array) $config</code>
-    </RedundantCast>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(array) $config</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="3">
+    <RedundantConditionGivenDocblockType>
       <code>gettype($item)</code>
-      <code>is_int($item['priority'])</code>
-      <code>isset($item['priority']) &amp;&amp; is_int($item['priority'])</code>
+      <code><![CDATA[is_int($item['priority'])]]></code>
+      <code><![CDATA[isset($item['priority']) && is_int($item['priority'])]]></code>
     </RedundantConditionGivenDocblockType>
-    <TypeDoesNotContainType occurrences="1">
-      <code>! is_array($config['routes'])</code>
+    <TypeDoesNotContainType>
+      <code><![CDATA[! is_array($config['routes'])]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="src/Container/ApplicationFactory.php">
-    <MixedArgument occurrences="5">
-      <code>$container-&gt;get(ApplicationPipeline::class)</code>
-      <code>$container-&gt;get(MiddlewareFactory::class)</code>
-      <code>$container-&gt;get(RequestHandlerRunnerInterface::class)</code>
+    <MixedArgument>
+      <code><![CDATA[$container->get(ApplicationPipeline::class)]]></code>
+      <code><![CDATA[$container->get(MiddlewareFactory::class)]]></code>
+      <code><![CDATA[$container->get(RequestHandlerRunnerInterface::class)]]></code>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>ApplicationPipeline</code>
     </UndefinedClass>
   </file>
   <file src="src/Container/ErrorHandlerFactory.php">
-    <MixedArgument occurrences="2">
-      <code>$container-&gt;get(ResponseInterface::class)</code>
+    <MixedArgument>
+      <code><![CDATA[$container->get(ResponseInterface::class)]]></code>
       <code>$generator</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$generator</code>
     </MixedAssignment>
   </file>
   <file src="src/Container/ErrorResponseGeneratorFactory.php">
-    <MixedArgument occurrences="4">
+    <MixedArgument>
       <code>$debug</code>
       <code>$errorHandlerConfig</code>
       <code>$renderer</code>
       <code>$template</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$errorHandlerConfig['template_error']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$errorHandlerConfig['template_error']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$debug</code>
       <code>$errorHandlerConfig</code>
       <code>$renderer</code>
@@ -77,99 +71,99 @@
     </MixedAssignment>
   </file>
   <file src="src/Container/FilterUsingXForwardedHeadersFactory.php">
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$appConfig[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY]</code>
       <code>$appConfig[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY][ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY]</code>
     </MixedArrayAccess>
   </file>
   <file src="src/Container/MiddlewareFactoryFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get(MiddlewareContainer::class)</code>
+    <MixedArgument>
+      <code><![CDATA[$container->get(MiddlewareContainer::class)]]></code>
     </MixedArgument>
   </file>
   <file src="src/Container/NotFoundHandlerFactory.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$errorHandlerConfig</code>
       <code>$renderer</code>
       <code>$template</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$errorHandlerConfig['template_404']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$errorHandlerConfig['template_404']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$errorHandlerConfig</code>
       <code>$renderer</code>
       <code>$template</code>
     </MixedAssignment>
   </file>
   <file src="src/Container/RequestHandlerRunnerFactory.php">
-    <MixedArgument occurrences="5">
-      <code>$container-&gt;get(ApplicationPipeline::class)</code>
-      <code>$container-&gt;get(EmitterInterface::class)</code>
-      <code>$container-&gt;get(ServerRequestErrorResponseGenerator::class)</code>
-      <code>$container-&gt;get(ServerRequestInterface::class)</code>
+    <MixedArgument>
+      <code><![CDATA[$container->get(ApplicationPipeline::class)]]></code>
+      <code><![CDATA[$container->get(EmitterInterface::class)]]></code>
+      <code><![CDATA[$container->get(ServerRequestErrorResponseGenerator::class)]]></code>
+      <code><![CDATA[$container->get(ServerRequestInterface::class)]]></code>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>ApplicationPipeline</code>
     </UndefinedClass>
   </file>
   <file src="src/Container/ServerRequestErrorResponseGeneratorFactory.php">
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$debug</code>
       <code>$renderer</code>
       <code>$template</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$debug</code>
       <code>$renderer</code>
       <code>$template</code>
     </MixedAssignment>
   </file>
   <file src="src/Container/ServerRequestFactoryFactory.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$filter</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$filter</code>
     </MixedAssignment>
   </file>
   <file src="src/Container/WhoopsErrorResponseGeneratorFactory.php">
-    <MixedArgument occurrences="1">
-      <code>$container-&gt;get('Mezzio\Whoops')</code>
+    <MixedArgument>
+      <code><![CDATA[$container->get('Mezzio\Whoops')]]></code>
     </MixedArgument>
   </file>
   <file src="src/Container/WhoopsFactory.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$config</code>
-      <code>$container-&gt;get('Mezzio\WhoopsPageHandler')</code>
+      <code><![CDATA[$container->get('Mezzio\WhoopsPageHandler')]]></code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$config</code>
     </MixedAssignment>
   </file>
   <file src="src/Container/WhoopsPageHandlerFactory.php">
-    <MixedArgument occurrences="2">
+    <MixedArgument>
       <code>$config</code>
       <code>$editor</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="1">
-      <code>$config['whoops']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$config['whoops']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$config</code>
       <code>$config</code>
       <code>$editor</code>
     </MixedAssignment>
   </file>
   <file src="src/Middleware/WhoopsErrorResponseGenerator.php">
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$handler</code>
       <code>$request</code>
       <code>$scriptName</code>
       <code>$uri</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="7">
+    <MixedMethodCall>
       <code>getAttributes</code>
       <code>getCookieParams</code>
       <code>getHeaders</code>
@@ -178,86 +172,86 @@
       <code>getQueryParams</code>
       <code>getServerParams</code>
     </MixedMethodCall>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_object($whoops)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/MiddlewareContainer.php">
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $service()</code>
     </InvalidStringClass>
-    <ParamNameMismatch occurrences="2">
+    <ParamNameMismatch>
       <code>$service</code>
       <code>$service</code>
     </ParamNameMismatch>
   </file>
   <file src="src/MiddlewareFactory.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>isIterable</code>
     </RedundantCondition>
   </file>
   <file src="src/Response/ServerRequestErrorResponseGenerator.php">
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>ServerRequestErrorResponseGenerator</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/ConfigProviderTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>$json['packages']</code>
-      <code>$package['extra']</code>
-      <code>$package['extra']['laminas']</code>
-      <code>$package['extra']['laminas']['config-provider']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$json['packages']]]></code>
+      <code><![CDATA[$package['extra']]]></code>
+      <code><![CDATA[$package['extra']['laminas']]]></code>
+      <code><![CDATA[$package['extra']['laminas']['config-provider']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$json</code>
       <code>$package</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
-      <code>new $package['extra']['laminas']['config-provider']()</code>
+    <MixedMethodCall>
+      <code><![CDATA[new $package['extra']['laminas']['config-provider']()]]></code>
     </MixedMethodCall>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>assertIsArray</code>
     </RedundantCondition>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>ApplicationPipeline</code>
     </UndefinedClass>
   </file>
   <file src="test/Container/ApplicationConfigInjectionDelegatorTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$pipeline</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$middleware</code>
       <code>$pipeline</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>SplQueue</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$r-&gt;getValue($pipeline)</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$r->getValue($pipeline)]]></code>
     </MixedReturnStatement>
   </file>
   <file src="test/Container/ApplicationFactoryTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>ApplicationPipeline</code>
     </UndefinedClass>
   </file>
   <file src="test/Container/ErrorHandlerFactoryTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$generator</code>
     </InvalidArgument>
   </file>
   <file src="test/Container/FilterUsingXForwardedHeadersFactoryTest.php">
-    <MoreSpecificReturnType occurrences="1">
-      <code>iterable&lt;string, array{0: string, 1: array&lt;string, string&gt;}&gt;</code>
+    <MoreSpecificReturnType>
+      <code><![CDATA[iterable<string, array{0: string, 1: array<string, string>}>]]></code>
     </MoreSpecificReturnType>
-    <UndefinedInterfaceMethod occurrences="5">
+    <UndefinedInterfaceMethod>
       <code>set</code>
       <code>set</code>
       <code>set</code>
@@ -266,156 +260,152 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="test/Container/NotFoundHandlerFactoryTest.php">
-    <MixedArgument occurrences="4">
-      <code>$this-&gt;container-&gt;get(ResponseInterface::class)</code>
-      <code>$this-&gt;container-&gt;get(ResponseInterface::class)</code>
-      <code>$this-&gt;container-&gt;get(ResponseInterface::class)</code>
-      <code>$this-&gt;container-&gt;get(ResponseInterface::class)</code>
+    <MixedArgument>
+      <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
+      <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
+      <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
+      <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
     </MixedArgument>
   </file>
   <file src="test/Container/RequestHandlerRunnerFactoryTest.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$errorGenerator</code>
     </InvalidArgument>
-    <InvalidFunctionCall occurrences="1">
+    <InvalidFunctionCall>
       <code>$errorGenerator($e)</code>
     </InvalidFunctionCall>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$toTest</code>
       <code>$toTest</code>
     </MixedAssignment>
-    <MixedFunctionCall occurrences="2">
+    <MixedFunctionCall>
       <code>$toTest($e)</code>
       <code>$toTest()</code>
     </MixedFunctionCall>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>ApplicationPipeline</code>
     </UndefinedClass>
   </file>
   <file src="test/Container/ResponseFactoryFactoryTest.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>assertIsCallable</code>
     </RedundantCondition>
   </file>
   <file src="test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$autoloader</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$autoloader</code>
     </MixedAssignment>
   </file>
   <file src="test/Container/ServerRequestFactoryFactoryTest.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>assertIsCallable</code>
     </RedundantCondition>
   </file>
   <file src="test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$autoloader</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$autoloader</code>
     </MixedAssignment>
   </file>
   <file src="test/Container/StreamFactoryFactoryTest.php">
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>assertIsCallable</code>
     </RedundantCondition>
   </file>
   <file src="test/Container/StreamFactoryFactoryWithoutDiactorosTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$autoloader</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$autoloader</code>
     </MixedAssignment>
   </file>
   <file src="test/Container/TestAsset/CallableInteropMiddleware.php">
-    <MissingParamType occurrences="1">
+    <MissingParamType>
       <code>$request</code>
     </MissingParamType>
   </file>
   <file src="test/Container/TestAsset/CallableMiddleware.php">
-    <MissingParamType occurrences="2">
+    <MissingParamType>
       <code>$request</code>
       <code>$response</code>
     </MissingParamType>
   </file>
   <file src="test/Container/TestAsset/InteropMiddleware.php">
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>ResponseInterface</code>
     </InvalidReturnType>
   </file>
   <file src="test/Container/WhoopsFactoryTest.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$handler</code>
       <code>$stack</code>
     </MixedAssignment>
   </file>
   <file src="test/Container/WhoopsPageHandlerFactoryTest.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/ExceptionTest.php">
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>Generator</code>
       <code>Generator</code>
     </MixedInferredReturnType>
-    <PossiblyFalseOperand occurrences="1">
-      <code>strrpos(ExceptionInterface::class, '\\')</code>
+    <PossiblyFalseOperand>
+      <code><![CDATA[strrpos(ExceptionInterface::class, '\\')]]></code>
     </PossiblyFalseOperand>
   </file>
   <file src="test/Middleware/ErrorResponseGeneratorTest.php">
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$body</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
   </file>
   <file src="test/Middleware/WhoopsErrorResponseGeneratorTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$whoops</code>
       <code>$whoops</code>
     </InvalidArgument>
   </file>
   <file src="test/MiddlewareFactoryTest.php">
-    <MissingClosureParamType occurrences="2">
+    <MissingClosureParamType>
       <code>$handler</code>
       <code>$request</code>
     </MissingClosureParamType>
-    <MixedArgument occurrences="3">
-      <code>$r-&gt;getValue($pipeline)</code>
-      <code>$r-&gt;getValue($pipeline)</code>
+    <MixedArgument>
+      <code><![CDATA[$r->getValue($pipeline)]]></code>
+      <code><![CDATA[$r->getValue($pipeline)]]></code>
       <code>$received[0]</code>
     </MixedArgument>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$received</code>
     </MixedAssignment>
-    <UnusedClosureParam occurrences="2">
-      <code>$handler</code>
-      <code>$request</code>
-    </UnusedClosureParam>
   </file>
   <file src="test/Response/CallableResponseFactoryDecoratorTest.php">
-    <InternalMethod occurrences="1">
-      <code>new CallableResponseFactoryDecorator(fn(): ResponseInterface =&gt; $this-&gt;response)</code>
+    <InternalMethod>
+      <code><![CDATA[new CallableResponseFactoryDecorator(fn(): ResponseInterface => $this->response)]]></code>
     </InternalMethod>
   </file>
   <file src="test/Router/IntegrationTest.php">
-    <ArgumentTypeCoercion occurrences="2">
+    <ArgumentTypeCoercion>
       <code>$router</code>
       <code>$router</code>
     </ArgumentTypeCoercion>
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $adapter()</code>
     </InvalidStringClass>
-    <MissingClosureParamType occurrences="16">
+    <MissingClosureParamType>
       <code>$handler</code>
       <code>$handler</code>
       <code>$handler</code>
@@ -433,37 +423,18 @@
       <code>$req</code>
       <code>$req</code>
     </MissingClosureParamType>
-    <MixedInferredReturnType occurrences="1"/>
-    <UnusedClosureParam occurrences="17">
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$handler</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-      <code>$req</code>
-    </UnusedClosureParam>
+    <MixedInferredReturnType/>
   </file>
   <file src="test/TestAsset/InteropMiddleware.php">
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>ResponseInterface</code>
     </InvalidReturnType>
-    <ParamNameMismatch occurrences="1">
+    <ParamNameMismatch>
       <code>$delegate</code>
     </ParamNameMismatch>
   </file>
   <file src="test/TestAsset/InvokableMiddleware.php">
-    <MissingParamType occurrences="6">
+    <MissingParamType>
       <code>$next</code>
       <code>$next</code>
       <code>$request</code>
@@ -471,10 +442,10 @@
       <code>$response</code>
       <code>$response</code>
     </MissingParamType>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>staticallyCallableMiddleware</code>
     </MissingReturnType>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>withHeader</code>
     </MixedMethodCall>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -8,6 +8,7 @@
   <file src="src/Container/ApplicationConfigInjectionDelegator.php">
     <DocblockTypeContradiction>
       <code>! is_array($item)</code>
+      <code>1</code>
       <code>is_array($methods)</code>
       <code>is_object($item)</code>
     </DocblockTypeContradiction>
@@ -23,6 +24,7 @@
     </MixedOperand>
     <RedundantCastGivenDocblockType>
       <code>(array) $config</code>
+      <code>(array) $config</code>
     </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
       <code>gettype($item)</code>
@@ -36,8 +38,6 @@
   <file src="src/Container/ApplicationFactory.php">
     <MixedArgument>
       <code><![CDATA[$container->get(ApplicationPipeline::class)]]></code>
-      <code><![CDATA[$container->get(MiddlewareFactory::class)]]></code>
-      <code><![CDATA[$container->get(RequestHandlerRunnerInterface::class)]]></code>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
     <UndefinedClass>
@@ -45,19 +45,17 @@
     </UndefinedClass>
   </file>
   <file src="src/Container/ErrorHandlerFactory.php">
-    <MixedArgument>
+    <InvalidArgument>
       <code><![CDATA[$container->get(ResponseInterface::class)]]></code>
+    </InvalidArgument>
+    <PossiblyInvalidArgument>
       <code>$generator</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$generator</code>
-    </MixedAssignment>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Container/ErrorResponseGeneratorFactory.php">
     <MixedArgument>
       <code>$debug</code>
       <code>$errorHandlerConfig</code>
-      <code>$renderer</code>
       <code>$template</code>
     </MixedArgument>
     <MixedArrayAccess>
@@ -66,9 +64,11 @@
     <MixedAssignment>
       <code>$debug</code>
       <code>$errorHandlerConfig</code>
-      <code>$renderer</code>
       <code>$template</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code>$renderer</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Container/FilterUsingXForwardedHeadersFactory.php">
     <MixedArrayAccess>
@@ -76,15 +76,9 @@
       <code>$appConfig[ConfigProvider::DIACTOROS_CONFIG_KEY][ConfigProvider::DIACTOROS_SERVER_REQUEST_FILTER_CONFIG_KEY][ConfigProvider::DIACTOROS_X_FORWARDED_FILTER_CONFIG_KEY]</code>
     </MixedArrayAccess>
   </file>
-  <file src="src/Container/MiddlewareFactoryFactory.php">
-    <MixedArgument>
-      <code><![CDATA[$container->get(MiddlewareContainer::class)]]></code>
-    </MixedArgument>
-  </file>
   <file src="src/Container/NotFoundHandlerFactory.php">
     <MixedArgument>
       <code>$errorHandlerConfig</code>
-      <code>$renderer</code>
       <code>$template</code>
     </MixedArgument>
     <MixedArrayAccess>
@@ -92,16 +86,18 @@
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$errorHandlerConfig</code>
-      <code>$renderer</code>
       <code>$template</code>
     </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code>$renderer</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Container/RequestHandlerRunnerFactory.php">
+    <InvalidArgument>
+      <code><![CDATA[$container->get(ServerRequestInterface::class)]]></code>
+    </InvalidArgument>
     <MixedArgument>
       <code><![CDATA[$container->get(ApplicationPipeline::class)]]></code>
-      <code><![CDATA[$container->get(EmitterInterface::class)]]></code>
-      <code><![CDATA[$container->get(ServerRequestErrorResponseGenerator::class)]]></code>
-      <code><![CDATA[$container->get(ServerRequestInterface::class)]]></code>
       <code>ApplicationPipeline::class</code>
     </MixedArgument>
     <UndefinedClass>
@@ -111,22 +107,15 @@
   <file src="src/Container/ServerRequestErrorResponseGeneratorFactory.php">
     <MixedArgument>
       <code>$debug</code>
-      <code>$renderer</code>
       <code>$template</code>
     </MixedArgument>
     <MixedAssignment>
       <code>$debug</code>
-      <code>$renderer</code>
       <code>$template</code>
     </MixedAssignment>
-  </file>
-  <file src="src/Container/ServerRequestFactoryFactory.php">
-    <MixedArgument>
-      <code>$filter</code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code>$filter</code>
-    </MixedAssignment>
+    <PossiblyInvalidArgument>
+      <code>$renderer</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="src/Container/WhoopsErrorResponseGeneratorFactory.php">
     <MixedArgument>
@@ -180,10 +169,6 @@
     <InvalidStringClass>
       <code>new $service()</code>
     </InvalidStringClass>
-    <ParamNameMismatch>
-      <code>$service</code>
-      <code>$service</code>
-    </ParamNameMismatch>
   </file>
   <file src="src/MiddlewareFactory.php">
     <RedundantCondition>
@@ -247,25 +232,13 @@
       <code>$generator</code>
     </InvalidArgument>
   </file>
-  <file src="test/Container/FilterUsingXForwardedHeadersFactoryTest.php">
-    <MoreSpecificReturnType>
-      <code><![CDATA[iterable<string, array{0: string, 1: array<string, string>}>]]></code>
-    </MoreSpecificReturnType>
-    <UndefinedInterfaceMethod>
-      <code>set</code>
-      <code>set</code>
-      <code>set</code>
-      <code>set</code>
-      <code>set</code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="test/Container/NotFoundHandlerFactoryTest.php">
-    <MixedArgument>
+    <InvalidArgument>
       <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
       <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
       <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
       <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
-    </MixedArgument>
+    </InvalidArgument>
   </file>
   <file src="test/Container/RequestHandlerRunnerFactoryTest.php">
     <InvalidArgument>
@@ -350,27 +323,23 @@
       <code>$stack</code>
     </MixedAssignment>
   </file>
-  <file src="test/Container/WhoopsPageHandlerFactoryTest.php">
-    <MixedInferredReturnType>
-      <code>array</code>
-    </MixedInferredReturnType>
-  </file>
   <file src="test/ExceptionTest.php">
     <MixedInferredReturnType>
-      <code>Generator</code>
       <code>Generator</code>
     </MixedInferredReturnType>
     <PossiblyFalseOperand>
       <code><![CDATA[strrpos(ExceptionInterface::class, '\\')]]></code>
     </PossiblyFalseOperand>
   </file>
+  <file src="test/InMemoryContainer.php">
+    <MixedReturnStatement>
+      <code><![CDATA[$this->services[$id]]]></code>
+    </MixedReturnStatement>
+  </file>
   <file src="test/Middleware/ErrorResponseGeneratorTest.php">
     <MixedArgument>
       <code>$body</code>
     </MixedArgument>
-    <MixedInferredReturnType>
-      <code>array</code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/Middleware/WhoopsErrorResponseGeneratorTest.php">
     <InvalidArgument>
@@ -423,7 +392,6 @@
       <code>$req</code>
       <code>$req</code>
     </MissingClosureParamType>
-    <MixedInferredReturnType/>
   </file>
   <file src="test/TestAsset/InteropMiddleware.php">
     <InvalidReturnType>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -324,9 +324,6 @@
     </MixedAssignment>
   </file>
   <file src="test/ExceptionTest.php">
-    <MixedInferredReturnType>
-      <code>Generator</code>
-    </MixedInferredReturnType>
     <PossiblyFalseOperand>
       <code><![CDATA[strrpos(ExceptionInterface::class, '\\')]]></code>
     </PossiblyFalseOperand>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -6,6 +6,8 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="psalm-baseline.xml"
     findUnusedPsalmSuppress="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
 >
     <projectFiles>
         <directory name="bin"/>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -56,4 +56,8 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    
+    <stubs>
+        <file name=".psr-container.php.stub"/>
+    </stubs>
 </psalm>

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -13,6 +13,7 @@ use Mezzio\Application;
 use Mezzio\MiddlewareFactory;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteCollector;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -106,9 +107,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testPipeCanAcceptSingleMiddlewareArgument($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -126,9 +127,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testPipeCanAcceptAPathArgument($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -156,9 +157,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testRouteAcceptsPathAndMiddlewareOnly($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -184,9 +185,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testRouteAcceptsPathMiddlewareAndMethodsOnly($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -212,9 +213,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testRouteAcceptsPathMiddlewareMethodsAndName($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -251,9 +252,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider requestMethodsWithValidMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('requestMethodsWithValidMiddleware')]
     public function testSpecificRouteMethodsCanAcceptOnlyPathAndMiddleware(string $method, $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -279,9 +280,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider requestMethodsWithValidMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('requestMethodsWithValidMiddleware')]
     public function testSpecificRouteMethodsCanAcceptPathMiddlewareAndName(string $method, $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -307,9 +308,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testAnyMethodPassesNullForMethodWhenNoNamePresent($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
@@ -335,9 +336,9 @@ class ApplicationTest extends TestCase
     }
 
     /**
-     * @dataProvider validMiddleware
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('validMiddleware')]
     public function testAnyMethodPassesNullForMethodWhenAllArgumentsPresent($middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -95,7 +95,7 @@ class ApplicationTest extends TestCase
     }
 
     /** @return iterable<string, array{0: MiddlewareParam}> */
-    public function validMiddleware(): iterable
+    public static function validMiddleware(): iterable
     {
         // @codingStandardsIgnoreStart
         yield 'string'   => ['service'];
@@ -240,10 +240,10 @@ class ApplicationTest extends TestCase
     }
 
     /** @return iterable<string, array{0: string, 1: MiddlewareParam}> */
-    public function requestMethodsWithValidMiddleware(): iterable
+    public static function requestMethodsWithValidMiddleware(): iterable
     {
         foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
-            foreach ($this->validMiddleware() as $key => $data) {
+            foreach (self::validMiddleware() as $key => $data) {
                 $name = sprintf('%s-%s', $method, $key);
                 yield $name => [$method, $data[0]];
             }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -100,7 +100,6 @@ class ApplicationTest extends TestCase
         // @codingStandardsIgnoreStart
         yield 'string'   => ['service'];
         yield 'array'    => [['middleware', 'service']];
-        /** @psalm-suppress UnusedClosureParam */
         yield 'callable' => [fn ( ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface => new Response()];
         yield 'instance' => [new MiddlewarePipe()];
         // @codingStandardsIgnoreEnd
@@ -148,7 +147,6 @@ class ApplicationTest extends TestCase
 
     public function testPipeNonSlashPathOnNonStringPipeProduceTypeError(): void
     {
-        /** @psalm-suppress UnusedClosureParam */
         $middleware1 = static fn(ServerRequestInterface $req, RequestHandlerInterface $res): ResponseInterface
             => new Response();
         $middleware2 = $this->createMockMiddleware();

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -128,7 +128,7 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
     }
 
     /** @return list<array{MiddlewareParam}> */
-    public function callableMiddlewares(): array
+    public static function callableMiddlewares(): array
     {
         return [
             ['HelloWorld'],

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -19,6 +19,7 @@ use Mezzio\Router\RouterInterface;
 use MezzioTest\InMemoryContainer;
 use MezzioTest\TestAsset\InvokableMiddleware;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Server\MiddlewareInterface;
@@ -153,9 +154,9 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
     }
 
     /**
-     * @dataProvider callableMiddlewares
      * @param MiddlewareParam $middleware
      */
+    #[DataProvider('callableMiddlewares')]
     public function testInjectRoutesFromConfigSetsUpRoutesFromConfig($middleware): void
     {
         $this->container->set('HelloWorld', true);

--- a/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
+++ b/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
@@ -9,6 +9,7 @@ use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
 use Mezzio\ConfigProvider;
 use Mezzio\Container\FilterUsingXForwardedHeadersFactory;
 use MezzioTest\InMemoryContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FilterUsingXForwardedHeadersFactoryTest extends TestCase
@@ -35,7 +36,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
         yield 'public' => ['4.4.4.4'];
     }
 
-    /** @dataProvider randomIpGenerator */
+    #[DataProvider('randomIpGenerator')]
     public function testIfNoConfigPresentFactoryReturnsFilterThatDoesNotTrustAny(string $remoteAddr): void
     {
         $factory = new FilterUsingXForwardedHeadersFactory();
@@ -73,7 +74,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
         }
     }
 
-    /** @dataProvider trustAnyProvider */
+    #[DataProvider('trustAnyProvider')]
     public function testIfWildcardProxyAddressSpecifiedReturnsFilterConfiguredToTrustAny(
         string $remoteAddr,
         array $headers
@@ -107,7 +108,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
         $this->assertSame($headers[FilterUsingXForwardedHeaders::HEADER_PROTO], $uri->getScheme());
     }
 
-    /** @dataProvider randomIpGenerator */
+    #[DataProvider('randomIpGenerator')]
     public function testEmptyProxiesListDoesNotTrustXForwardedRequests(string $remoteAddr): void
     {
         $this->container->set('config', [
@@ -141,7 +142,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
         $this->assertSame($request, $filteredRequest);
     }
 
-    /** @dataProvider randomIpGenerator */
+    #[DataProvider('randomIpGenerator')]
     public function testMissingHeadersListTrustsAllXForwardedRequestsForMatchedProxies(string $remoteAddr): void
     {
         $this->container->set('config', [
@@ -178,7 +179,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
         $this->assertSame('https', $uri->getScheme());
     }
 
-    /** @dataProvider randomIpGenerator */
+    #[DataProvider('randomIpGenerator')]
     public function testEmptyHeadersListTrustsNoRequests(string $remoteAddr): void
     {
         $this->container->set('config', [
@@ -328,7 +329,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
         ];
     }
 
-    /** @dataProvider trustedProxiesAndHeaders */
+    #[DataProvider('trustedProxiesAndHeaders')]
     public function testCombinedProxiesAndHeadersDefineTrust(
         bool $expectUnfiltered,
         array $config,

--- a/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
+++ b/test/Container/FilterUsingXForwardedHeadersFactoryTest.php
@@ -8,48 +8,16 @@ use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFilter\FilterUsingXForwardedHeaders;
 use Mezzio\ConfigProvider;
 use Mezzio\Container\FilterUsingXForwardedHeadersFactory;
+use MezzioTest\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerInterface;
-
-use function array_key_exists;
 
 class FilterUsingXForwardedHeadersFactoryTest extends TestCase
 {
-    private ContainerInterface $container;
+    private InMemoryContainer $container;
 
     public function setUp(): void
     {
-        $this->container = new class () implements ContainerInterface {
-            /** @psalm-var array<string, mixed> */
-            private array $services = [];
-
-            /**
-             * @param string $id
-             */
-            public function has($id): bool
-            {
-                return array_key_exists($id, $this->services);
-            }
-
-            /**
-             * @param string $id
-             * @return mixed
-             */
-            public function get($id)
-            {
-                if (! array_key_exists($id, $this->services)) {
-                    return null;
-                }
-
-                return $this->services[$id];
-            }
-
-            public function set(string $id, mixed $value): void
-            {
-                $this->services[$id] = $value;
-            }
-        };
-
+        $this->container = new InMemoryContainer();
         $this->container->set('config', []);
     }
 
@@ -59,7 +27,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
     }
 
     /** @psalm-return iterable<string, array{0: string}> */
-    public function randomIpGenerator(): iterable
+    public static function randomIpGenerator(): iterable
     {
         yield 'class-a' => ['10.1.1.1'];
         yield 'class-c' => ['192.168.1.1'];
@@ -89,7 +57,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
     }
 
     /** @psalm-return iterable<string, array{0: string, 1: array<string, string>}> */
-    public function trustAnyProvider(): iterable
+    public static function trustAnyProvider(): iterable
     {
         $headers = [
             FilterUsingXForwardedHeaders::HEADER_HOST  => 'api.example.com',
@@ -97,9 +65,11 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
             FilterUsingXForwardedHeaders::HEADER_PORT  => '4443',
         ];
 
-        foreach ($this->randomIpGenerator() as $name => $arguments) {
-            $arguments[] = $headers;
-            yield $name => $arguments;
+        foreach (self::randomIpGenerator() as $name => $arguments) {
+            yield $name => [
+                $arguments[0],
+                $headers,
+            ];
         }
     }
 
@@ -251,7 +221,7 @@ class FilterUsingXForwardedHeadersFactoryTest extends TestCase
      *     5: string
      * }>
      */
-    public function trustedProxiesAndHeaders(): iterable
+    public static function trustedProxiesAndHeaders(): iterable
     {
         yield 'single-proxy-single-header' => [
             false,

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -13,6 +13,7 @@ use Mezzio\Handler\NotFoundHandler;
 use Mezzio\Response\CallableResponseFactoryDecorator;
 use Mezzio\Template\TemplateRendererInterface;
 use MezzioTest\InMemoryContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -177,8 +178,8 @@ class NotFoundHandlerFactoryTest extends TestCase
 
     /**
      * @param array<string,mixed> $config
-     * @dataProvider configurationsWithOverriddenResponseInterfaceFactory
      */
+    #[DataProvider('configurationsWithOverriddenResponseInterfaceFactory')]
     public function testWontUseResponseFactoryInterfaceFromContainerWhenApplicationFactoryIsOverriden(
         array $config
     ): void {

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Container;
 
 use ArrayAccess;
 use Generator;
+use Laminas\Diactoros\Response\TextResponse;
 use Mezzio\Container\NotFoundHandlerFactory;
 use Mezzio\Container\ResponseFactoryFactory;
 use Mezzio\Handler\NotFoundHandler;
@@ -37,14 +38,14 @@ class NotFoundHandlerFactoryTest extends TestCase
     /**
      * @psalm-return Generator<non-empty-string,array{0:array<string,mixed>}>
      */
-    public function configurationsWithOverriddenResponseInterfaceFactory(): Generator
+    public static function configurationsWithOverriddenResponseInterfaceFactory(): Generator
     {
         yield 'default' => [
             [
                 'dependencies' => [
                     'factories' => [
                         ResponseInterface::class
-                            => fn(): ResponseInterface => $this->createMock(ResponseInterface::class),
+                            => fn(): ResponseInterface => new TextResponse('Foo'),
                     ],
                 ],
             ],
@@ -65,7 +66,7 @@ class NotFoundHandlerFactoryTest extends TestCase
                 'dependencies' => [
                     'delegators' => [
                         ResponseInterface::class => [
-                            fn(): ResponseInterface => $this->createMock(ResponseInterface::class),
+                            fn(): ResponseInterface => new TextResponse('Foo'),
                         ],
                     ],
                 ],

--- a/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
@@ -24,6 +24,8 @@ class ResponseFactoryFactoryWithoutDiactorosTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->markTestSkipped('De-registering the autoloader breaks PHPUnit since version 10');
+
         class_exists(InvalidServiceException::class);
 
         $this->container = $this->createMock(ContainerInterface::class);

--- a/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Container;
 
 use ArrayAccess;
 use Generator;
+use Laminas\Diactoros\Response\TextResponse;
 use Mezzio\Container\ResponseFactoryFactory;
 use Mezzio\Container\ServerRequestErrorResponseGeneratorFactory;
 use Mezzio\Response\CallableResponseFactoryDecorator;
@@ -30,14 +31,14 @@ class ServerRequestErrorResponseGeneratorFactoryTest extends TestCase
     /**
      * @psalm-return Generator<non-empty-string,array{0:array<string,mixed>}>
      */
-    public function configurationsWithOverriddenResponseInterfaceFactory(): Generator
+    public static function configurationsWithOverriddenResponseInterfaceFactory(): Generator
     {
         yield 'default' => [
             [
                 'dependencies' => [
                     'factories' => [
                         ResponseInterface::class
-                            => fn(): ResponseInterface => $this->createMock(ResponseInterface::class),
+                            => fn(): ResponseInterface => new TextResponse('Foo'),
                     ],
                 ],
             ],
@@ -58,7 +59,7 @@ class ServerRequestErrorResponseGeneratorFactoryTest extends TestCase
                 'dependencies' => [
                     'delegators' => [
                         ResponseInterface::class => [
-                            fn(): ResponseInterface => $this->createMock(ResponseInterface::class),
+                            fn(): ResponseInterface => new TextResponse('Foo'),
                         ],
                     ],
                 ],

--- a/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
@@ -13,6 +13,7 @@ use Mezzio\Response\CallableResponseFactoryDecorator;
 use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use Mezzio\Template\TemplateRendererInterface;
 use MezzioTest\InMemoryContainer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -151,8 +152,8 @@ class ServerRequestErrorResponseGeneratorFactoryTest extends TestCase
 
     /**
      * @param array<string,mixed> $config
-     * @dataProvider configurationsWithOverriddenResponseInterfaceFactory
      */
+    #[DataProvider('configurationsWithOverriddenResponseInterfaceFactory')]
     public function testWontUseResponseFactoryInterfaceFromContainerWhenApplicationFactoryIsOverriden(
         array $config
     ): void {

--- a/test/Container/ServerRequestFactoryFactoryTest.php
+++ b/test/Container/ServerRequestFactoryFactoryTest.php
@@ -9,6 +9,7 @@ use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFactory;
 use Laminas\Diactoros\ServerRequestFilter\FilterServerRequestInterface;
 use Mezzio\Container\ServerRequestFactoryFactory;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -33,9 +34,8 @@ class ServerRequestFactoryFactoryTest extends TestCase
      * cannot simply return a callable referencing the
      * ServerRequestFactory::fromGlobals method, but must be decorated as a
      * closure.
-     *
-     * @depends testFactoryReturnsCallable
      */
+    #[Depends('testFactoryReturnsCallable')]
     public function testFactoryIsAClosure(callable $factory): void
     {
         $this->assertNotSame([ServerRequestFactory::class, 'fromGlobals'], $factory);

--- a/test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php
@@ -24,6 +24,8 @@ class ServerRequestFactoryFactoryWithoutDiactorosTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->markTestSkipped('De-registering the autoloader breaks PHPUnit since version 10');
+
         class_exists(InvalidServiceException::class);
 
         $this->container = $this->createMock(ContainerInterface::class);

--- a/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
@@ -24,6 +24,8 @@ class StreamFactoryFactoryWithoutDiactorosTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->markTestSkipped('De-registering the autoloader breaks PHPUnit since version 10');
+
         class_exists(InvalidServiceException::class);
 
         $this->container = $this->createMock(ContainerInterface::class);

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -7,6 +7,10 @@ namespace MezzioTest\Container;
 use ArrayAccess;
 use Mezzio\Container\WhoopsFactory;
 use MezzioTest\InMemoryContainer;
+use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Whoops\Handler\JsonResponseHandler;
@@ -17,9 +21,7 @@ use Whoops\Util\Misc as WhoopsUtil;
 use function method_exists;
 use function sprintf;
 
-/**
- * @covers \Mezzio\Container\WhoopsFactory
- */
+#[CoversClass(WhoopsFactory::class)]
 class WhoopsFactoryTest extends TestCase
 {
     private InMemoryContainer $container;
@@ -73,13 +75,13 @@ class WhoopsFactoryTest extends TestCase
     }
 
     /**
-     * @backupGlobals enabled
-     * @depends       testWillInjectJsonResponseHandlerIfConfigurationExpectsIt
-     * @dataProvider  provideConfig
      * @param bool  $showsTrace
      * @param bool  $isAjaxOnly
      * @param bool  $requestIsAjax
      */
+    #[DataProvider('provideConfig')]
+    #[Depends('testWillInjectJsonResponseHandlerIfConfigurationExpectsIt')]
+    #[BackupGlobals(true)]
     public function testJsonResponseHandlerCanBeConfigured($showsTrace, $isAjaxOnly, $requestIsAjax): void
     {
         // Set for Whoops 2.x json handler detection

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -126,7 +126,7 @@ class WhoopsFactoryTest extends TestCase
     /**
      * @return iterable<string, bool[]>
      */
-    public function provideConfig(): iterable
+    public static function provideConfig(): iterable
     {
         // @codingStandardsIgnoreStart
         //    test case                        => showsTrace, isAjaxOnly, requestIsAjax

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -85,7 +85,8 @@ class WhoopsPageHandlerFactoryTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function invalidEditors(): array
+    /** @return array<string, array{0: mixed}> */
+    public static function invalidEditors(): array
     {
         return [
             'true'       => [true],

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -7,12 +7,12 @@ namespace MezzioTest\Container;
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\WhoopsPageHandlerFactory;
 use MezzioTest\InMemoryContainer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Whoops\Handler\PrettyPageHandler;
 
-/**
- * @covers Mezzio\Container\WhoopsPageHandlerFactory
- */
+#[CoversClass(WhoopsPageHandlerFactory::class)]
 class WhoopsPageHandlerFactoryTest extends TestCase
 {
     private InMemoryContainer $container;
@@ -100,9 +100,7 @@ class WhoopsPageHandlerFactoryTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalidEditors
-     */
+    #[DataProvider('invalidEditors')]
     public function testInvalidEditorWillRaiseException(mixed $editor): void
     {
         $config = ['whoops' => ['editor' => $editor]];

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -9,6 +9,7 @@ use Mezzio\Exception\ContainerNotRegisteredException;
 use Mezzio\Exception\ExceptionInterface;
 use Mezzio\Exception\InvalidMiddlewareException;
 use Mezzio\Exception\MissingDependencyException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
 use Throwable;
@@ -33,9 +34,7 @@ class ExceptionTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider exception
-     */
+    #[DataProvider('exception')]
     public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         $this->assertStringContainsString('Exception', $exception);
@@ -49,9 +48,7 @@ class ExceptionTest extends TestCase
         yield MissingDependencyException::class => [MissingDependencyException::class];
     }
 
-    /**
-     * @dataProvider containerException
-     */
+    #[DataProvider('containerException')]
     public function testExceptionIsInstanceOfContainerExceptionInterface(string $exception): void
     {
         $this->assertTrue(is_a($exception, ContainerExceptionInterface::class, true));

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -11,6 +11,7 @@ use Mezzio\Exception\InvalidMiddlewareException;
 use Mezzio\Exception\MissingDependencyException;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
+use Throwable;
 
 use function basename;
 use function glob;
@@ -20,7 +21,7 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function exception(): Generator
+    public static function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -41,7 +42,8 @@ class ExceptionTest extends TestCase
         $this->assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 
-    public function containerException(): Generator
+    /** @return Generator<class-string<Throwable>, array{0: class-string<Throwable>}> */
+    public static function containerException(): Generator
     {
         yield InvalidMiddlewareException::class => [InvalidMiddlewareException::class];
         yield MissingDependencyException::class => [MissingDependencyException::class];

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Handler;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Laminas\Diactoros\Response\TextResponse;
 use Laminas\Diactoros\Uri;
 use Mezzio\Handler\NotFoundHandler;
 use Mezzio\Template\TemplateRendererInterface;
@@ -124,22 +125,12 @@ class NotFoundHandlerTest extends TestCase
 
     public function testCanHandleCallableResponseFactory(): void
     {
-        $responseFactory = fn(): ResponseInterface => $this->response;
+        $response        = new TextResponse('Foo');
+        $responseFactory = fn(): ResponseInterface => $response;
+        $handler         = new NotFoundHandler($responseFactory);
+        $result          = $handler->handle($this->createMock(ServerRequestInterface::class));
 
-        $this->response
-            ->expects(self::exactly(2))
-            ->method('withStatus')
-            ->withConsecutive([200], [404])
-            ->willReturnSelf();
-
-        $this->response
-            ->expects(self::once())
-            ->method('getBody')
-            ->willReturn($this->createMock(StreamInterface::class));
-
-        $handler  = new NotFoundHandler($responseFactory);
-        $response = $handler->handle($this->createMock(ServerRequestInterface::class));
-
-        $this->assertSame($this->response, $response);
+        self::assertNotSame($response, $result);
+        self::assertSame(404, $result->getStatusCode());
     }
 }

--- a/test/InMemoryContainer.php
+++ b/test/InMemoryContainer.php
@@ -15,24 +15,20 @@ final class InMemoryContainer implements ContainerInterface
     /** @var array<string,mixed> */
     private array $services = [];
 
-    /**
-     * @param string $id
-     * @return mixed
-     */
-    public function get($id)
+    /** @inheritDoc */
+    public function get($id): mixed
     {
-        if (! $this->has($id)) {
+        if (! array_key_exists($id, $this->services)) {
             throw new class ($id . ' was not found') extends RuntimeException implements NotFoundExceptionInterface {
             };
         }
 
+        /** @psalm-return mixed */
+
         return $this->services[$id];
     }
 
-    /**
-     * @param string $id
-     */
-    public function has($id): bool
+    public function has(string $id): bool
     {
         return array_key_exists($id, $this->services);
     }

--- a/test/InMemoryContainer.php
+++ b/test/InMemoryContainer.php
@@ -28,7 +28,8 @@ final class InMemoryContainer implements ContainerInterface
         return $this->services[$id];
     }
 
-    public function has(string $id): bool
+    /** @param string $id */
+    public function has($id): bool
     {
         return array_key_exists($id, $this->services);
     }

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -96,7 +96,8 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertSame($response, $secondaryResponse);
     }
 
-    public function templates(): array
+    /** @return array<string, array{0:string|null, 1: string}> */
+    public static function templates(): array
     {
         return [
             'default' => [null, 'error::error'],

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -8,6 +8,7 @@ use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use Laminas\Diactoros\Uri;
 use Mezzio\Middleware\ErrorResponseGenerator;
 use Mezzio\Template\TemplateRendererInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -105,9 +106,7 @@ class ErrorResponseGeneratorTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider templates
-     */
+    #[DataProvider('templates')]
     public function testRendersTemplateWithoutErrorDetailsWhenRendererPresentAndNotInDebugMode(
         ?string $template,
         string $expected
@@ -156,9 +155,7 @@ class ErrorResponseGeneratorTest extends TestCase
         $this->assertSame($response, $secondaryResponse);
     }
 
-    /**
-     * @dataProvider templates
-     */
+    #[DataProvider('templates')]
     public function testRendersTemplateWithErrorDetailsWhenRendererPresentAndInDebugMode(
         ?string $template,
         string $expected

--- a/test/MiddlewareContainerTest.php
+++ b/test/MiddlewareContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MezzioTest;
 
+use ArrayObject;
 use Laminas\Stratigility\Middleware\RequestHandlerMiddleware;
 use Mezzio\Exception;
 use Mezzio\MiddlewareContainer;
@@ -51,16 +52,16 @@ class MiddlewareContainerTest extends TestCase
 
     public function testGetRaisesExceptionIfServiceSpecifiedDoesNotImplementMiddlewareInterface(): void
     {
-        $this->originContainer->set(self::class, $this);
+        $this->originContainer->set(ArrayObject::class, new ArrayObject());
 
         $this->expectException(Exception\InvalidMiddlewareException::class);
-        $this->container->get(self::class);
+        $this->container->get(ArrayObject::class);
     }
 
     public function testGetRaisesExceptionIfClassSpecifiedDoesNotImplementMiddlewareInterface(): void
     {
         $this->expectException(Exception\InvalidMiddlewareException::class);
-        $this->container->get(self::class);
+        $this->container->get(ArrayObject::class);
     }
 
     public function testGetReturnsServiceFromOriginContainer(): void

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -14,6 +14,7 @@ use Mezzio\Middleware\LazyLoadingMiddleware;
 use Mezzio\MiddlewareContainer;
 use Mezzio\MiddlewareFactory;
 use Mezzio\Router\Middleware\DispatchMiddleware;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -132,9 +133,7 @@ class MiddlewareFactoryTest extends TestCase
         yield 'object' => [(object) ['foo' => 'bar']];
     }
 
-    /**
-     * @dataProvider invalidMiddlewareTypes
-     */
+    #[DataProvider('invalidMiddlewareTypes')]
     public function testPrepareRaisesExceptionForTypesItDoesNotUnderstand(mixed $middleware): void
     {
         $this->expectException(Exception\InvalidMiddlewareException::class);
@@ -179,10 +178,10 @@ class MiddlewareFactoryTest extends TestCase
     }
 
     /**
-     * @dataProvider validPrepareTypes
      * @param MiddlewareParam $middleware
      * @param mixed $expected Expected type or value for use with assertion
      */
+    #[DataProvider('validPrepareTypes')]
     public function testPipelineAllowsAnyTypeSupportedByPrepare(
         $middleware,
         string $assertion,

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -42,7 +42,6 @@ class MiddlewareFactoryTest extends TestCase
     /** @return Closure(ServerRequestInterface, RequestHandlerInterface): ResponseInterface */
     private static function validCallable(): Closure
     {
-        /** @psalm-suppress UnusedClosureParam */
         return function (
             ServerRequestInterface $request,
             RequestHandlerInterface $handler

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -120,7 +120,7 @@ class MiddlewareFactoryTest extends TestCase
     }
 
     /** @return iterable<string, array{0: mixed}> */
-    public function invalidMiddlewareTypes(): iterable
+    public static function invalidMiddlewareTypes(): iterable
     {
         yield 'null' => [null];
         yield 'false' => [false];
@@ -168,7 +168,7 @@ class MiddlewareFactoryTest extends TestCase
      *     array{0: MiddlewareParam, 1: string, 2: MiddlewareParam}
      * >
      */
-    public function validPrepareTypes(): iterable
+    public static function validPrepareTypes(): iterable
     {
         yield 'service' => ['service', 'assertLazyLoadingMiddleware', 'service'];
 

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -24,6 +24,8 @@ use Mezzio\Router\Middleware\MethodNotAllowedMiddleware;
 use Mezzio\Router\Middleware\RouteMiddleware;
 use Mezzio\Router\RouteCollector;
 use Mezzio\Router\RouterInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
@@ -143,9 +145,9 @@ class IntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider routerAdapters
      * @psalm-param class-string<RouterInterface> $adapter
      */
+    #[DataProvider('routerAdapters')]
     public function testRoutingDoesNotMatchMethod(string $adapter): void
     {
         $app     = $this->createApplicationWithGetPost($adapter);
@@ -163,10 +165,10 @@ class IntegrationTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-expressive/issues/40
      *
-     * @group 40
-     * @dataProvider routerAdapters
      * @psalm-param class-string<RouterInterface> $adapter
      */
+    #[DataProvider('routerAdapters')]
+    #[Group('40')]
     public function testRoutingWithSamePathWithoutName(string $adapter): void
     {
         $app = $this->createApplicationWithGetPost($adapter);
@@ -189,10 +191,10 @@ class IntegrationTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-expressive/issues/40
      *
-     * @group 40
-     * @dataProvider routerAdapters
      * @psalm-param class-string<RouterInterface> $adapter
      */
+    #[DataProvider('routerAdapters')]
+    #[Group('40')]
     public function testRoutingWithSamePathWithName(string $adapter): void
     {
         $app = $this->createApplicationWithGetPost($adapter, 'foo-get', 'foo-post');
@@ -215,10 +217,10 @@ class IntegrationTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-expressive/issues/40
      *
-     * @group 40
-     * @dataProvider routerAdapters
      * @psalm-param class-string<RouterInterface> $adapter
      */
+    #[DataProvider('routerAdapters')]
+    #[Group('40')]
     public function testRoutingWithSamePathWithRouteWithoutName(string $adapter): void
     {
         $app = $this->createApplicationWithRouteGetPost($adapter);
@@ -241,9 +243,9 @@ class IntegrationTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-expressive/issues/40
      *
-     * @dataProvider routerAdapters
      * @psalm-param class-string<RouterInterface> $adapter
      */
+    #[DataProvider('routerAdapters')]
     public function testRoutingWithSamePathWithRouteWithName(string $adapter): void
     {
         $app = $this->createApplicationWithRouteGetPost($adapter, 'foo-get', 'foo-post');
@@ -266,10 +268,10 @@ class IntegrationTest extends TestCase
     /**
      * @see https://github.com/zendframework/zend-expressive/issues/40
      *
-     * @group 40
-     * @dataProvider routerAdapters
      * @psalm-param class-string<RouterInterface> $adapter
      */
+    #[DataProvider('routerAdapters')]
+    #[Group('40')]
     public function testRoutingWithSamePathWithRouteWithMultipleMethods(string $adapter): void
     {
         $router = new $adapter();
@@ -335,10 +337,10 @@ class IntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider routerAdaptersForHttpMethods
      * @psalm-param class-string<RouterInterface> $adapter
      * @psalm-param RequestMethod::METHOD_* $method
      */
+    #[DataProvider('routerAdaptersForHttpMethods')]
     public function testMatchWithAllHttpMethods(string $adapter, string $method): void
     {
         $router = new $adapter();
@@ -380,10 +382,10 @@ class IntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider allowedMethod
      * @psalm-param class-string<RouterInterface> $adapter
      * @psalm-param RequestMethod::METHOD_* $method
      */
+    #[DataProvider('allowedMethod')]
     public function testAllowedMethodsWhenOnlyPutMethodSet(string $adapter, string $method): void
     {
         $router = new $adapter();
@@ -417,10 +419,8 @@ class IntegrationTest extends TestCase
         $this->assertSame('', (string) $result->getBody());
     }
 
-    /**
-     * @group 74
-     * @dataProvider routerAdapters
-     */
+    #[DataProvider('routerAdapters')]
+    #[Group('74')]
     public function testWithOnlyRootPathRouteDefinedRoutingToSubPathsShouldDelegate(string $adapter): void
     {
         $router = new $adapter();

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -71,7 +71,7 @@ class IntegrationTest extends TestCase
      *
      * @psalm-return iterable<string, array{class-string<RouterInterface>}>
      */
-    public function routerAdapters(): iterable
+    public static function routerAdapters(): iterable
     {
         yield 'aura' => [AuraRouter::class];
         yield 'fast-route' => [FastRouteRouter::class];
@@ -314,7 +314,7 @@ class IntegrationTest extends TestCase
      *     1: RequestMethod::METHOD_*
      * }>
      */
-    public function routerAdaptersForHttpMethods(): iterable
+    public static function routerAdaptersForHttpMethods(): iterable
     {
         $allMethods = [
             RequestMethod::METHOD_GET,
@@ -325,7 +325,7 @@ class IntegrationTest extends TestCase
             RequestMethod::METHOD_HEAD,
             RequestMethod::METHOD_OPTIONS,
         ];
-        foreach ($this->routerAdapters() as $adapterName => $adapter) {
+        foreach (self::routerAdapters() as $adapterName => $adapter) {
             $adapter = array_pop($adapter);
             foreach ($allMethods as $method) {
                 $name = sprintf('%s-%s', $adapterName, $method);
@@ -364,12 +364,12 @@ class IntegrationTest extends TestCase
     }
 
     /**
-     * @psalm-return iterable<array{
+     * @psalm-return iterable<string, array{
      *     0: class-string<RouterInterface>,
      *     1: RequestMethod::METHOD_*
      * }>
      */
-    public function allowedMethod(): iterable
+    public static function allowedMethod(): iterable
     {
         yield 'aura-head'    => [AuraRouter::class, RequestMethod::METHOD_HEAD];
         yield 'aura-options' => [AuraRouter::class, RequestMethod::METHOD_OPTIONS];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Closes #141 

There are 3 tests that de-register the composer autoloader to simulate a project where Diactoros is not installed, these are now skipped because PHPUnit crashes without the autoloader now.

I can't currently see a way of simulating this without running these tests in a separate job after a `composer remove laminas/laminas-diactoros`

