### PR TITLE
Allow access to `LazyLoadingMiddleware::$middlewareName`

### DIFF
--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -13,7 +13,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class LazyLoadingMiddleware implements MiddlewareInterface
 {
-    public function __construct(private MiddlewareContainer $container, private string $middlewareName)
+    public function __construct(private MiddlewareContainer $container, public readonly string $middlewareClass)
     {
     }
 
@@ -23,14 +23,6 @@ class LazyLoadingMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $middleware = $this->container->get($this->middlewareName);
-        return $middleware->process($request, $handler);
-    }
-    
-    /**
-     * For inspection of the lazy loaded middleware
-     */
-    public function getMiddlewareName(): string {
-        return $this->middlewareName;
+        return $this->container->get($this->middlewareClass)->process($request, $handler);
     }
 }

--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -26,4 +26,11 @@ class LazyLoadingMiddleware implements MiddlewareInterface
         $middleware = $this->container->get($this->middlewareName);
         return $middleware->process($request, $handler);
     }
+    
+    /**
+     * For inspection of the lazy loaded middleware
+     */
+    public function getMiddlewareName(): string {
+        return $this->middlewareName;
+    }
 }


### PR DESCRIPTION
Added public getter to lazy loading middleware middlewareName to allow for inspection by userland code


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Tell us about why this change is necessary:
I want to be able to inspect a routed request handler from a middleware, but when I inspect the matched route the matched request handler property is private so I cannot use it.

- Are you fixing a bug or providing a failing unit test to demonstrate a bug? No

- Are you adding documentation?
No

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
No

- Are you fixing a BC Break?
No

- Are you adding something the library currently does not support?
Yes - possibly

- Are you refactoring code?
No

