### PR TITLE
Introduce `RouteCollectorDelegator`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^2.1",
         "laminas/laminas-stratigility": "^3.5",
-        "mezzio/mezzio-router": "^3.7",
+        "mezzio/mezzio-router": "^3.15.0",
         "mezzio/mezzio-template": "^2.2",
         "psr/container": "^1.0||^2.0",
         "psr/http-factory": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "30afb42c53411ec3579af5ade55c19e9",
+    "content-hash": "2f914c3d4eef1a2b7de6fb7fdb3d76a1",
     "packages": [
         {
             "name": "fig/http-message-util",

--- a/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
+++ b/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
@@ -1,12 +1,86 @@
 # How can I autowire routes and pipelines?
 
-Sometimes you may find you'd like to keep route definitions close to the
-handlers and middleware they will invoke. This is particularly important if you
-want to re-use a module or library in another project.
+Sometimes you may find you'd like to keep route definitions close to the handlers and middleware they will invoke.
+This is particularly important if you want to re-use a module or library in another project.
 
-In this recipe, we'll demonstrate two mechanisms for doing so. One is a built-in
-[delegator factory](../features/container/delegator-factories.md), and the other
-is a custom delegator factory.
+In this recipe, we'll demonstrate some mechanisms for doing so.
+One is a built-in [delegator factory](../features/container/delegator-factories.md) around the route collector, another delegates around the application instance allowing a declarative config driven approach and the other is a custom delegator factory.
+
+## Using a `RouteProvider`
+
+Mezzio ships with a delegator factory around the [`RouteCollector`](../features/router/route-collector.md) that will execute any registered classes that implement the interface `Mezzio\Router\RouteProviderInterface`.
+
+This is the most predictable and portable way of registering routes, but there are several steps to get a "Route Provider" to execute.
+
+### First, Create the RouteProvider
+
+The following "Route Provider" adds a single route to the route collector.
+Because the Route Provider is _simple_ it needs no constructor dependencies, but, you could create a more advanced route provider for your module that extracts routing information from configuration, or scans the codebase for attributes for example.
+All Route Providers, once registered are retrieved from the application DI container, so you are free to inject any services or configuration that you require.
+
+```php
+use Laminas\Diactoros\Response\TextResponse;
+use Mezzio\MiddlewareFactoryInterface;
+use Mezzio\Router\RouteCollectorInterface;
+use Mezzio\Router\RouteProviderInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class MyRouteProvider implements RouteProviderInterface
+{
+    public function registerRoutes(
+        RouteCollectorInterface $routeCollector,
+        MiddlewareFactoryInterface $middlewareFactory,
+    ): void {
+        /**
+         * Add a single trivial route using a closure to produce a response:
+         */
+        $routeCollector->get(
+            '/hello-world',
+            $middlewareFactory->callable(function (RequestInterface $request): ResponseInterface {
+                return new TextResponse('Hi There!');
+            }),
+            'hello',
+        );
+    }
+}
+```
+
+### Second: Register the Route Provider in Your DI Container
+
+Depending on the DI Container in use you will need to register a [factory](../features/container/factories.md) for your Route Provider.
+When using Laminas Service Manager, the configuration would look like this:
+
+```php
+use Laminas\ServiceManager\Factory\InvokableFactory;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            MyRouteProvider::class => InvokableFactory::class,
+        ],
+    ],
+];
+```
+
+Our Route Provider is 'invokable', meaning it has no constructor dependencies and can simply be `new`ed.
+The Laminas `InvokableFactory` is a convenient way of declaring a factory for such a service.
+
+### Third: Register the Route Provider with the Delegator
+
+There is one final configuration item to ensure that your route provider is executed when the `RouteCollector` is retrieved from the DI container:
+
+```php
+return [
+    'router' => [
+        'route-providers' => [
+            MyRouteProvider::class,
+        ],
+    ],
+]
+```
+
+Using "Route Providers" ensures that routes are registered when you interact with Mezzio components _outside_ the middleware application lifecycle such as on the command line, providing you make proper use of dependency injection elsewhere in your codebase.
 
 ## ApplicationConfigInjectionDelegator
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -42,7 +42,7 @@ class ConfigProvider
     {
         // phpcs:disable Generic.Files.LineLength.TooLong
         return [
-            'aliases'   => [
+            'aliases'    => [
                 DEFAULT_DELEGATE                     => Handler\NotFoundHandler::class,
                 DISPATCH_MIDDLEWARE                  => Router\Middleware\DispatchMiddleware::class,
                 IMPLICIT_HEAD_MIDDLEWARE             => Router\Middleware\ImplicitHeadMiddleware::class,
@@ -64,7 +64,7 @@ class ConfigProvider
                 'Zend\HttpHandlerRunner\RequestHandlerRunner'                  => RequestHandlerRunner::class,
                 'Zend\Expressive\Response\ServerRequestErrorResponseGenerator' => Response\ServerRequestErrorResponseGenerator::class,
             ],
-            'factories' => [
+            'factories'  => [
                 Application::class             => Container\ApplicationFactory::class,
                 'Mezzio\ApplicationPipeline'   => Container\ApplicationPipelineFactory::class,
                 EmitterInterface::class        => Container\EmitterFactory::class,
@@ -79,6 +79,11 @@ class ConfigProvider
                 Response\ServerRequestErrorResponseGenerator::class => Container\ServerRequestErrorResponseGeneratorFactory::class,
                 ServerRequestInterface::class                       => Container\ServerRequestFactoryFactory::class,
                 StreamInterface::class                              => Container\StreamFactoryFactory::class,
+            ],
+            'delegators' => [
+                Router\RouteCollector::class => [
+                    Router\RouteCollectorDelegator::class,
+                ],
             ],
         ];
         // phpcs:enable Generic.Files.LineLength.TooLong

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Router;
+
+use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
+use Mezzio\MiddlewareFactoryInterface;
+use Psr\Container\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+use function assert;
+use function is_a;
+use function is_array;
+use function is_string;
+
+final class RouteCollectorDelegator implements DelegatorFactoryInterface
+{
+    /**
+     * RouteCollector Delegator
+     *
+     * Delegates around the RouteCollectorInterface and triggers all registered route providers prior to returning the
+     * RouteCollector instance.
+     *
+     * @inheritDoc
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $name,
+        callable $callback,
+        ?array $options = null
+    ): RouteCollectorInterface {
+        $collector = $callback();
+        Assert::isInstanceOf($collector, RouteCollectorInterface::class);
+
+        $config = $container->get('config');
+        Assert::isArray($config);
+
+        $routerConfig = $config['router'] ?? [];
+        assert(is_array($routerConfig));
+        $providers = $routerConfig['route-providers'] ?? [];
+        assert(is_array($providers));
+
+        $middlewareFactory = $container->get(MiddlewareFactoryInterface::class);
+        foreach ($providers as $provider) {
+            assert(is_string($provider));
+            assert(is_a($provider, RouteProviderInterface::class, true));
+
+            $instance = $container->has($provider)
+                ? $container->get($provider)
+                : new $provider();
+
+            $instance->registerRoutes($collector, $middlewareFactory);
+        }
+
+        return $collector;
+    }
+}

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -10,7 +10,6 @@ use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
 
 use function assert;
-use function is_a;
 use function is_array;
 use function is_string;
 
@@ -44,13 +43,11 @@ final class RouteCollectorDelegator implements DelegatorFactoryInterface
         $middlewareFactory = $container->get(MiddlewareFactoryInterface::class);
         foreach ($providers as $provider) {
             assert(is_string($provider));
-            assert(is_a($provider, RouteProviderInterface::class, true));
+            /** @psalm-suppress MixedAssignment */
+            $provider = $container->get($provider);
+            assert($provider instanceof RouteProviderInterface);
 
-            $instance = $container->has($provider)
-                ? $container->get($provider)
-                : new $provider();
-
-            $instance->registerRoutes($collector, $middlewareFactory);
+            $provider->registerRoutes($collector, $middlewareFactory);
         }
 
         return $collector;

--- a/src/Router/RouteProviderInterface.php
+++ b/src/Router/RouteProviderInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Router;
+
+use Mezzio\MiddlewareFactoryInterface;
+
+interface RouteProviderInterface
+{
+    public function registerRoutes(
+        RouteCollectorInterface $routeCollector,
+        MiddlewareFactoryInterface $middlewareFactory,
+    ): void;
+}

--- a/test/Router/ExampleRouteProvider.php
+++ b/test/Router/ExampleRouteProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Router;
+
+use Mezzio\MiddlewareFactoryInterface;
+use Mezzio\Router\RouteCollectorInterface;
+use Mezzio\Router\RouteProviderInterface;
+use MezzioTest\TestAsset\NoOpMiddleware;
+
+final class ExampleRouteProvider implements RouteProviderInterface
+{
+    public function registerRoutes(
+        RouteCollectorInterface $routeCollector,
+        MiddlewareFactoryInterface $middlewareFactory,
+    ): void {
+        $routeCollector->get(
+            '/example-route',
+            $middlewareFactory->prepare([NoOpMiddleware::class]),
+            'example-route',
+        );
+    }
+}

--- a/test/Router/RouteCollectorDelegatorIntegrationTest.php
+++ b/test/Router/RouteCollectorDelegatorIntegrationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Router;
+
+use Laminas\Router\ConfigProvider as LaminasRouterConfigProvider;
+use Laminas\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\ServiceManager;
+use Mezzio\ConfigProvider as MezzioConfigProvider;
+use Mezzio\Router\ConfigProvider as RouterConfigProvider;
+use Mezzio\Router\LaminasRouter\ConfigProvider as MezzioLaminasRouterConfigProvider;
+use Mezzio\Router\Route;
+use Mezzio\Router\RouteCollector;
+use Mezzio\Router\RouteCollectorInterface;
+use PHPUnit\Framework\TestCase;
+
+use function array_filter;
+use function array_merge_recursive;
+use function assert;
+use function count;
+use function is_array;
+use function reset;
+use function sprintf;
+
+/** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
+final class RouteCollectorDelegatorIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+    }
+
+    private function serviceManagerWithConfig(array $config): ServiceManager
+    {
+        $config = array_merge_recursive(
+            (new MezzioConfigProvider())(),
+            (new RouterConfigProvider())(),
+            (new LaminasRouterConfigProvider())(),
+            (new MezzioLaminasRouterConfigProvider())(),
+            $config,
+        );
+
+        $dependencies = $config['dependencies'] ?? [];
+        assert(is_array($dependencies));
+        /** @psalm-suppress MixedAssignment */
+        $dependencies['services'] = $dependencies['services'] ?? [];
+        assert(is_array($dependencies['services']));
+        $dependencies['services']['config'] = $config;
+        /** @psalm-var ServiceManagerConfiguration $dependencies */
+
+        return new ServiceManager($dependencies);
+    }
+
+    public function testThatTheRouteWillBeInjectedIntoTheRouteCollectorWhenNoFactoryIsDefined(): void
+    {
+        $config = [
+            'router' => [
+                'route-providers' => [
+                    ExampleRouteProvider::class,
+                ],
+            ],
+        ];
+
+        $container = $this->serviceManagerWithConfig($config);
+
+        $collector = $container->get(RouteCollectorInterface::class);
+        assert($collector instanceof RouteCollector);
+
+        $this->assertContainsRouteWithNameAndPath('example-route', '/example-route', $collector->getRoutes());
+    }
+
+    public function testThatTheRouteWillBeInjectedIntoTheRouteCollectorWhenAFactoryIsDefinedForTheProvider(): void
+    {
+        $config = [
+            'dependencies' => [
+                'factories' => [
+                    ExampleRouteProvider::class => InvokableFactory::class,
+                ],
+            ],
+            'router'       => [
+                'route-providers' => [
+                    ExampleRouteProvider::class,
+                ],
+            ],
+        ];
+
+        $container = $this->serviceManagerWithConfig($config);
+
+        $collector = $container->get(RouteCollectorInterface::class);
+        assert($collector instanceof RouteCollector);
+
+        $this->assertContainsRouteWithNameAndPath('example-route', '/example-route', $collector->getRoutes());
+    }
+
+    private function assertContainsRouteWithNameAndPath(string $name, string $path, array $routes): void
+    {
+        self::assertGreaterThanOrEqual(1, count($routes), 'Expected a non-empty list of routes');
+
+        $routes = array_filter($routes, static fn (Route $route): bool => $route->getName() === $name);
+
+        self::assertCount(1, $routes, sprintf(
+            'Expected the list of routes to contain a route with the name "%s" but none was found',
+            $name,
+        ));
+
+        $route = reset($routes);
+        self::assertInstanceOf(Route::class, $route);
+
+        self::assertSame($path, $route->getPath());
+    }
+}

--- a/test/Router/RouteCollectorDelegatorIntegrationTest.php
+++ b/test/Router/RouteCollectorDelegatorIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MezzioTest\Router;
 
 use Laminas\Router\ConfigProvider as LaminasRouterConfigProvider;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use Laminas\ServiceManager\ServiceManager;
 use Mezzio\ConfigProvider as MezzioConfigProvider;
@@ -51,7 +52,7 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
         return new ServiceManager($dependencies);
     }
 
-    public function testThatTheRouteWillBeInjectedIntoTheRouteCollectorWhenNoFactoryIsDefined(): void
+    public function testThatAnExceptionIsThrownWhenAListedRouteProviderIsNotAvailableInTheContainer(): void
     {
         $config = [
             'router' => [
@@ -63,10 +64,10 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
 
         $container = $this->serviceManagerWithConfig($config);
 
-        $collector = $container->get(RouteCollectorInterface::class);
-        assert($collector instanceof RouteCollector);
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(ExampleRouteProvider::class);
 
-        $this->assertContainsRouteWithNameAndPath('example-route', '/example-route', $collector->getRoutes());
+        $container->get(RouteCollectorInterface::class);
     }
 
     public function testThatTheRouteWillBeInjectedIntoTheRouteCollectorWhenAFactoryIsDefinedForTheProvider(): void

--- a/test/TestAsset/NoOpMiddleware.php
+++ b/test/TestAsset/NoOpMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types = 1);
+namespace MezzioTest\TestAsset;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class NoOpMiddleware implements MiddlewareInterface {
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

Introduces an interface `RouteProviderInterface` with a single method `registerRoutes`.

This method accepts the `RouteCollectorInterface` and the `MiddlewareFactory`. Implementors can then easily inject routes into the application at the point where the collector is constructed by listing the provider class name under `$config['router']['route-providers']`

Hopefully, this provides a consistent way of ensuring that routes are available in all environments. Assuming that you want to produce application routes from the CLI _(because you're perhaps generating HTML email in a worker)_, the routes will be automatically registered as soon as you attempt to create a route via any of the shipped routers, because they all have a dependency on the collector.

The delegator that makes this happen checks the container for the named route provider. If the provider is not available in the container, <strike>it will be newed without constructor args</strike>, the usual `ServiceNotFound` exception will be thrown.

### Why here and not in Mezzio\Router?

It's far more convenient to have the `MiddlewareFactory` available to the RouteProvider so that users can `$factory->prepare([A::class, B::class])` etc. The MiddlewareFactory is not available in `Mezzio\Router` without declaring a dependency on Mezzio there.

This is something that I implement every time I create a Mezzio application - it's particularly useful if you want to collate your route configuration on a per-module basis, and the benefit of not needing to fetch the `Application` from the container in order to generate routes is also very helpful…

### Possible issues

Ideally, we'd delegate around the `RouteCollectorInterface` not the concrete `RouteCollector`, however it's not possible to delegate around an alias.

This could be solved if we changed that for v4 of `mezzio-router`, i.e. Point the interface at the factory, but that might be a particuarly annoying BC break there.
