### PR TITLE
Improve the Features section of the documentation

### DIFF
--- a/docs/book/v4/getting-started/features.md
+++ b/docs/book/v4/getting-started/features.md
@@ -34,7 +34,7 @@ Mezzio builds on [laminas-stratigility](https://docs.laminas.dev/laminas-stratig
 to provide a robust convenience layer on which to build applications. The
 features it provides include:
 
-- **Routing**
+### Routing
 
   Stratigility provides limited, literal matching only via its
   `PathMiddlewareDecorator`. Mezzio allows you to utilize dynamic routing
@@ -48,21 +48,21 @@ features it provides include:
   routing library that best fits the project needs. By default, we provide
   wrappers for Aura.Router, FastRoute, and the laminas-router.
 
-- **PSR-11 Container**
+### PSR-11 Container
 
   Mezzio encourages the use of Dependency Injection, and defines its
   `Application` class to compose a [PSR-11](https://www.php-fig.org/psr/psr-11)
   `ContainerInterface` instance. The container is used to lazy-load middleware,
   whether it is piped (Stratigility interface) or routed (Mezzio).
 
-- **Templating**
+### Templating
 
   While Mezzio does not assume templating is being used, it provides a
   templating abstraction. Developers can write middleware that typehints on
   this abstraction, and assume that the underlying adapter will provide
   layout support and namespaced template support.
 
-- **Error Handling**
+### Error Handling
 
   Applications should handle errors gracefully, but also handle them differently
   in development versus production. Mezzio provides both basic error

--- a/docs/book/v4/getting-started/features.md
+++ b/docs/book/v4/getting-started/features.md
@@ -35,12 +35,15 @@ The features it provides include:
 
 ### Powerful Routing
 
-Stratigility provides limited, literal route matching via its `PathMiddlewareDecorator`.
-Mezzio, however, allows you to utilize dynamic routing capabilities from a variety of router packages, providing much more fine-grained matching capabilities.
-Its routing layer also allows restricting matched routes to specific HTTP methods, and will return a [405 Not Allowed][405-not-allowed-url] response with an [Allow HTTP header][allow-http-header-url] containing the allowed HTTP methods for invalid requests.
+Stratigility provides the foundation for Mezzio's routing. 
+Stratigility only provides limited, literal route matching via `PathMiddlewareDecorator`.
+However, Mezzio builds on this, providing an abstracted routing layer that allows the developer to choose the routing library that best fits the project needs.
 
-Routing is abstracted in Mezzio, allowing the developer to choose the routing library that best fits the project needs.
-By default, we provide wrappers for [Aura.Router][aura-router-url], [FastRoute][fastroute-url], and the [laminas-router][laminas-router-url].
+And, among other features, it:
+
+- Supports dynamic routing capabilities from a variety of router packages, including [FastRoute][fastroute-url], and [laminas-router][laminas-router-url]
+- Provides much more fine-grained matching capabilities than Stratigility does
+- It allows restricting matched routes to specific HTTP methods and returns [405 Not Allowed][405-not-allowed-url] responses with an [Allow HTTP header][allow-http-header-url] containing the allowed HTTP methods for invalid requests
 
 ### A PSR-11 Container
 
@@ -49,13 +52,14 @@ The container is used to lazy-load middleware, whether it is piped (Stratigility
 
 ### Flexible Templating
 
-While Mezzio does not assume templating is being used, it provides a templating abstraction.
-Developers can write middleware that typehints on this abstraction, and assume that the underlying adapter will provide layout support and namespaced template support.
+While Mezzio does not assume templating is being used, it provides a templating abstraction layer, allowing developers to choose the templating package that best suits their needs.
+In addition, developers can write middleware that typehints on this abstraction, and assume that the underlying templating package will provide layout support and namespaced template support.
+By default, Mezzio provides wrappers for [Plates][plates-url], and [Twig][twig-url], and [laminas-view][laminas-view-url].
 
 ### Error Handling
 
 Applications should handle errors gracefully, but also handle them differently in development versus production.
-Mezzio provides both basic error handling via Stratigility's own `ErrorHandler` implementation, providing specialized error response generators that can perform templating or use [Whoops][whoops-url].
+Mezzio provides both basic error handling via Stratigility's own `ErrorHandler` implementation, providing specialized error response generators that can perform templating, and integrates with [Whoops][whoops-url].
 
 ## Flow Overview
 
@@ -203,8 +207,10 @@ The main points to remember are:
 
 [405-not-allowed-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
 [allow-http-header-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow
-[aura-router-url]: https://auraphp.com/packages/2.x/Router
 [fastroute-url]: https://github.com/nikic/FastRoute
 [laminas-router-url]: https://docs.laminas.dev/laminas-router/routing/
+[laminas-view-url]: https://docs.laminas.dev/laminas-view/
+[plates-url]: https://platesphp.com/
 [psr11-url]: https://www.php-fig.org/psr/psr-11
+[twig-url]: https://twig.symfony.com/
 [whoops-url]: http://filp.github.io/whoops/

--- a/docs/book/v4/getting-started/features.md
+++ b/docs/book/v4/getting-started/features.md
@@ -30,45 +30,32 @@ With Mezzio, you can build middleware applications such as the following:
 
 ## Features
 
-Mezzio builds on [laminas-stratigility](https://docs.laminas.dev/laminas-stratigility/)
-to provide a robust convenience layer on which to build applications. The
-features it provides include:
+Mezzio builds on [laminas-stratigility](https://docs.laminas.dev/laminas-stratigility/) (Stratigility) to provide a robust convenience layer on which to build applications.
+The features it provides include:
 
-### Routing
+### Powerful Routing
 
-  Stratigility provides limited, literal matching only via its
-  `PathMiddlewareDecorator`. Mezzio allows you to utilize dynamic routing
-  capabilities from a variety of routers, providing much more fine-grained
-  matching capabilities. The routing layer also allows restricting matched
-  routes to specific HTTP methods, and will return "405 Not Allowed" responses
-  with an "Allow" HTTP header containing allowed HTTP methods for invalid
-  requests.
+Stratigility provides limited, literal route matching via its `PathMiddlewareDecorator`.
+Mezzio, however, allows you to utilize dynamic routing capabilities from a variety of router packages, providing much more fine-grained matching capabilities.
+Its routing layer also allows restricting matched routes to specific HTTP methods, and will return a [405 Not Allowed][405-not-allowed-url] response with an [Allow HTTP header][allow-http-header-url] containing the allowed HTTP methods for invalid requests.
 
-  Routing is abstracted in Mezzio, allowing the developer to choose the
-  routing library that best fits the project needs. By default, we provide
-  wrappers for Aura.Router, FastRoute, and the laminas-router.
+Routing is abstracted in Mezzio, allowing the developer to choose the routing library that best fits the project needs.
+By default, we provide wrappers for [Aura.Router][aura-router-url], [FastRoute][fastroute-url], and the [laminas-router][laminas-router-url].
 
-### PSR-11 Container
+### A PSR-11 Container
 
-  Mezzio encourages the use of Dependency Injection, and defines its
-  `Application` class to compose a [PSR-11](https://www.php-fig.org/psr/psr-11)
-  `ContainerInterface` instance. The container is used to lazy-load middleware,
-  whether it is piped (Stratigility interface) or routed (Mezzio).
+Mezzio encourages the use of dependency injection, and defines its core `Application` class to compose a [PSR-11][psr11-url] `ContainerInterface` instance.
+The container is used to lazy-load middleware, whether it is piped (Stratigility interface) or routed (Mezzio).
 
-### Templating
+### Flexible Templating
 
-  While Mezzio does not assume templating is being used, it provides a
-  templating abstraction. Developers can write middleware that typehints on
-  this abstraction, and assume that the underlying adapter will provide
-  layout support and namespaced template support.
+While Mezzio does not assume templating is being used, it provides a templating abstraction.
+Developers can write middleware that typehints on this abstraction, and assume that the underlying adapter will provide layout support and namespaced template support.
 
 ### Error Handling
 
-  Applications should handle errors gracefully, but also handle them differently
-  in development versus production. Mezzio provides both basic error
-  handling via Stratigility's own `ErrorHandler` implementation, providing
-  specialized error response generators that can perform templating or use
-  Whoops.
+Applications should handle errors gracefully, but also handle them differently in development versus production.
+Mezzio provides both basic error handling via Stratigility's own `ErrorHandler` implementation, providing specialized error response generators that can perform templating or use [Whoops][whoops-url].
 
 ## Flow Overview
 
@@ -213,3 +200,11 @@ The main points to remember are:
   rules that map to them.
 - _You_ get to control the workflow of your application by deciding the order in
   which middleware is queued.
+
+[405-not-allowed-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405
+[allow-http-header-url]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow
+[aura-router-url]: https://auraphp.com/packages/2.x/Router
+[fastroute-url]: https://github.com/nikic/FastRoute
+[laminas-router-url]: https://docs.laminas.dev/laminas-router/routing/
+[psr11-url]: https://www.php-fig.org/psr/psr-11
+[whoops-url]: http://filp.github.io/whoops/


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The intention of this change is to improve the readability, formatting, and pitch of the [Features](https://docs.mezzio.dev/mezzio/v3/getting-started/features/) section of the Getting Started section of the documentation.

It comprises a small set of changes for a series of different reasons.

Firstly, as this is likely one of the first sections of the docs a new/first-time reader may go to, the language has been reworked to be a bit more sales-like and a little less technical. This is because this section of the docs should really tell the reader what's in it for them, encouraging them to keep exploring and learning.

Secondly, it changes the section's headers from bullet points to level three headers. This makes them both easier to read and easier for the reader to scan.

Thirdly, from the perspective of maintenance, sentences have been changed to be all one one line, not split up over multiple lines and the links have been extracted from being directly embedded with the text to be [reference-style links](https://www.markdownguide.org/basic-syntax/#reference-style-links). Personally, I find these easier to work with and maintain.