### PR TITLE
Remove `DelegatorFactory` implementation from the `RouteCollectorDelegator`

### DIFF
--- a/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
+++ b/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
@@ -10,6 +10,8 @@ One is a built-in [delegator factory](../features/container/delegator-factories.
 
 Mezzio ships with a delegator factory around the [`RouteCollector`](../features/router/route-collector.md) that will execute any registered classes that implement the interface `Mezzio\Router\RouteProviderInterface`.
 
+In order to make use of this feature, the DI container that you use, must [support "Delegator Factories"](../features/container/delegator-factories.md).
+
 This is the most predictable and portable way of registering routes, but there are several steps to get a "Route Provider" to execute.
 
 ### First, Create the RouteProvider

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio\Router;
 
-use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
 use Mezzio\MiddlewareFactoryInterface;
 use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
@@ -13,21 +12,18 @@ use function assert;
 use function is_array;
 use function is_string;
 
-final class RouteCollectorDelegator implements DelegatorFactoryInterface
+final class RouteCollectorDelegator
 {
     /**
      * RouteCollector Delegator
      *
      * Delegates around the RouteCollectorInterface and triggers all registered route providers prior to returning the
      * RouteCollector instance.
-     *
-     * @inheritDoc
      */
     public function __invoke(
         ContainerInterface $container,
-        $name,
+        string $name,
         callable $callback,
-        ?array $options = null
     ): RouteCollectorInterface {
         $collector = $callback();
         Assert::isInstanceOf($collector, RouteCollectorInterface::class);


### PR DESCRIPTION
Users may not be using `Laminas\ServiceManager` meaning that they will experience exceptions due to the delegator implementing the delegator interface from a package which is not installed.

This is a BC break due to removing the interface. Whilst we're breaking BC, we might as well also update the signature for `__invoke`.

3.22.0 hasn't been out for long, so hopefully this BC breaking fix for a BC Break is permissable!

Closes #216 