### PR TITLE
Merge release 3.22.1 into 4.0.x

### DIFF
--- a/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
+++ b/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
@@ -10,6 +10,8 @@ One is a built-in [delegator factory](../features/container/delegator-factories.
 
 Mezzio ships with a delegator factory around the [`RouteCollector`](../features/router/route-collector.md) that will execute any registered classes that implement the interface `Mezzio\Router\RouteProviderInterface`.
 
+In order to make use of this feature, the DI container that you use, must [support "Delegator Factories"](../features/container/delegator-factories.md).
+
 This is the most predictable and portable way of registering routes, but there are several steps to get a "Route Provider" to execute.
 
 ### First, Create the RouteProvider

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio\Router;
 
-use Laminas\ServiceManager\Factory\DelegatorFactoryInterface;
 use Mezzio\MiddlewareFactoryInterface;
 use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
@@ -13,21 +12,18 @@ use function assert;
 use function is_array;
 use function is_string;
 
-final class RouteCollectorDelegator implements DelegatorFactoryInterface
+final class RouteCollectorDelegator
 {
     /**
      * RouteCollector Delegator
      *
      * Delegates around the RouteCollectorInterface and triggers all registered route providers prior to returning the
      * RouteCollector instance.
-     *
-     * @inheritDoc
      */
     public function __invoke(
         ContainerInterface $container,
-        $name,
+        string $name,
         callable $callback,
-        ?array $options = null
     ): RouteCollectorInterface {
         $collector = $callback();
         Assert::isInstanceOf($collector, RouteCollectorInterface::class);


### PR DESCRIPTION
### Release Notes for [3.22.1](https://github.com/mezzio/mezzio/milestone/48)

Includes a fix for the `RouteCollectorDelegator` feature introduced in `3.22.0`.

This new delegator mistakenly implemented the `DelegatorFactoryInterface` from the `Laminas\ServiceManager` package, neglecting to take into account that users of `mezzio/mezzio` may not have chosen to install `laminas/laminas-servicemanager`.

The fix for this BC break, is itself a technical BC break, but given that 3.22.0 has only been out for a couple of days, we've decided to release the fix in a patch.

### 3.22.1

- Total issues resolved: **1**
- Total pull requests resolved: **1**
- Total contributors: **2**

#### BC Break,Bug

 - [217: Remove `DelegatorFactory` implementation from the `RouteCollectorDelegator`](https://github.com/mezzio/mezzio/pull/217) thanks to @gsteel and @Tri-Le
