### PR TITLE
Allow `config` to be an `ArrayObject` in `RouteCollectorDelegator`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "laminas/laminas-diactoros": "^3.8.0",
         "laminas/laminas-servicemanager": "^3.23.1",
         "mezzio/mezzio-fastroute": "^3.14",
-        "mezzio/mezzio-laminasrouter": "^3.11",
+        "mezzio/mezzio-laminasrouter": "^3.12",
         "phpunit/phpunit": "^11.5.42",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.13.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09dbbfe71a9f7c899a788f3b4d4b5284",
+    "content-hash": "c804d467eb0f9642fca69a1eee56a1bc",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -213,20 +213,20 @@
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-                "reference": "b14da3519c650e9436e410cfedee6f860312eff9"
+                "reference": "181eaeeb838ad3d80fbbcfb0657a46bc212bbd4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/b14da3519c650e9436e410cfedee6f860312eff9",
-                "reference": "b14da3519c650e9436e410cfedee6f860312eff9",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/181eaeeb838ad3d80fbbcfb0657a46bc212bbd4e",
+                "reference": "181eaeeb838ad3d80fbbcfb0657a46bc212bbd4e",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/http-message": "^1.0 || ^2.0",
                 "psr/http-message-implementation": "^1.0 || ^2.0",
                 "psr/http-server-handler": "^1.0"
@@ -276,7 +276,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-05-13T21:21:16+00:00"
+            "time": "2025-10-12T20:58:29+00:00"
         },
         {
             "name": "laminas/laminas-stratigility",
@@ -3236,16 +3236,16 @@
         },
         {
             "name": "mezzio/mezzio-laminasrouter",
-            "version": "3.11.0",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-laminasrouter.git",
-                "reference": "d0bd7431494ad0f5efc02cc060b65f815be8dee0"
+                "reference": "99be8034f49a0ecebe3de464cece6fefa40c276c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-laminasrouter/zipball/d0bd7431494ad0f5efc02cc060b65f815be8dee0",
-                "reference": "d0bd7431494ad0f5efc02cc060b65f815be8dee0",
+                "url": "https://api.github.com/repos/mezzio/mezzio-laminasrouter/zipball/99be8034f49a0ecebe3de464cece6fefa40c276c",
+                "reference": "99be8034f49a0ecebe3de464cece6fefa40c276c",
                 "shasum": ""
             },
             "require": {
@@ -3253,20 +3253,20 @@
                 "laminas/laminas-psr7bridge": "^1.0.0",
                 "laminas/laminas-router": "^3.10.0",
                 "mezzio/mezzio-router": "^3.14 || ^4.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
                 "psr/http-message": "^1.0.1 || ^2.0.0"
             },
             "conflict": {
                 "zendframework/zend-expressive-zendrouter": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~3.0.0",
-                "laminas/laminas-diactoros": "^2.25.2 || ^3.4.0",
-                "laminas/laminas-i18n": "^2.29.0",
-                "laminas/laminas-stratigility": "^4.0.2",
-                "phpunit/phpunit": "^10.5.36",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^2.25.2 || ^3.8.0",
+                "laminas/laminas-i18n": "^2.30.0",
+                "laminas/laminas-stratigility": "^4.2.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "extra": {
@@ -3307,7 +3307,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-04-27T09:51:58+00:00"
+            "time": "2025-10-13T10:23:08+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Router;
 
+use ArrayAccess;
 use Mezzio\MiddlewareFactoryInterface;
 use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
@@ -29,7 +30,7 @@ final class RouteCollectorDelegator
         Assert::isInstanceOf($collector, RouteCollectorInterface::class);
 
         $config = $container->get('config');
-        Assert::isArray($config);
+        assert(is_array($config) || $config instanceof ArrayAccess);
 
         $routerConfig = $config['router'] ?? [];
         assert(is_array($routerConfig));

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio\Router;
 
-use ArrayAccess;
 use Mezzio\MiddlewareFactoryInterface;
 use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;

--- a/src/Router/RouteCollectorDelegator.php
+++ b/src/Router/RouteCollectorDelegator.php
@@ -30,7 +30,7 @@ final class RouteCollectorDelegator
         Assert::isInstanceOf($collector, RouteCollectorInterface::class);
 
         $config = $container->get('config');
-        assert(is_array($config) || $config instanceof ArrayAccess);
+        Assert::isArrayAccessible($config);
 
         $routerConfig = $config['router'] ?? [];
         assert(is_array($routerConfig));

--- a/test/Router/RouteCollectorDelegatorIntegrationTest.php
+++ b/test/Router/RouteCollectorDelegatorIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MezzioTest\Router;
 
+use ArrayObject;
 use Laminas\Router\ConfigProvider as LaminasRouterConfigProvider;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
@@ -14,6 +15,7 @@ use Mezzio\Router\LaminasRouter\ConfigProvider as MezzioLaminasRouterConfigProvi
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteCollector;
 use Mezzio\Router\RouteCollectorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function array_filter;
@@ -27,11 +29,16 @@ use function sprintf;
 /** @psalm-import-type ServiceManagerConfiguration from ServiceManager */
 final class RouteCollectorDelegatorIntegrationTest extends TestCase
 {
-    protected function setUp(): void
+    /** @return array<string, array{0: bool}> */
+    public static function useArrayObject(): array
     {
+        return [
+            'Config as Array'        => [false],
+            'Config as Array Object' => [true],
+        ];
     }
 
-    private function serviceManagerWithConfig(array $config): ServiceManager
+    private function serviceManagerWithConfig(array $config, bool $asArrayObject): ServiceManager
     {
         $config = array_merge_recursive(
             (new MezzioConfigProvider())(),
@@ -46,14 +53,16 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
         /** @psalm-suppress MixedAssignment */
         $dependencies['services'] = $dependencies['services'] ?? [];
         assert(is_array($dependencies['services']));
-        $dependencies['services']['config'] = $config;
+        $dependencies['services']['config'] = $asArrayObject ? new ArrayObject($config) : $config;
         /** @psalm-var ServiceManagerConfiguration $dependencies */
 
         return new ServiceManager($dependencies);
     }
 
-    public function testThatAnExceptionIsThrownWhenAListedRouteProviderIsNotAvailableInTheContainer(): void
-    {
+    #[DataProvider('useArrayObject')]
+    public function testThatAnExceptionIsThrownWhenAListedRouteProviderIsNotAvailableInTheContainer(
+        bool $arrayObject,
+    ): void {
         $config = [
             'router' => [
                 'route-providers' => [
@@ -62,7 +71,7 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
             ],
         ];
 
-        $container = $this->serviceManagerWithConfig($config);
+        $container = $this->serviceManagerWithConfig($config, $arrayObject);
 
         $this->expectException(ServiceNotFoundException::class);
         $this->expectExceptionMessage(ExampleRouteProvider::class);
@@ -70,8 +79,10 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
         $container->get(RouteCollectorInterface::class);
     }
 
-    public function testThatTheRouteWillBeInjectedIntoTheRouteCollectorWhenAFactoryIsDefinedForTheProvider(): void
-    {
+    #[DataProvider('useArrayObject')]
+    public function testThatTheRouteWillBeInjectedIntoTheRouteCollectorWhenAFactoryIsDefinedForTheProvider(
+        bool $arrayObject,
+    ): void {
         $config = [
             'dependencies' => [
                 'factories' => [
@@ -85,7 +96,7 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
             ],
         ];
 
-        $container = $this->serviceManagerWithConfig($config);
+        $container = $this->serviceManagerWithConfig($config, $arrayObject);
 
         $collector = $container->get(RouteCollectorInterface::class);
         assert($collector instanceof RouteCollector);


### PR DESCRIPTION
Whilst working on upgrading the skeleton for 8.5 compat, I've discovered that [`jsoumelidis/zend-sf-di-config`](https://github.com/jsoumelidis/zend-sf-di-config/blob/master/src/Config.php#L40) converts application wide config to an `ArrayObject`, meaning that anyone using this lib with Symfony's container, (shipped by default in the skeleton), will be experiencing assertion failures as the delegator is shipped already wired up.