### PR TITLE
Upgrade laminas-stratigility to v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "fig/http-message-util": "^1.1.5",
         "laminas/laminas-httphandlerrunner": "^2.1",
-        "laminas/laminas-stratigility": "^3.5",
+        "laminas/laminas-stratigility": "^4.3",
         "mezzio/mezzio-router": "^3.15.0",
         "mezzio/mezzio-template": "^2.2",
         "psr/container": "^1.0||^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c804d467eb0f9642fca69a1eee56a1bc",
+    "content-hash": "d73d3e00b3048d16eb170495c8b01f87",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -152,32 +152,32 @@
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.17.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba"
+                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/df1ef9503299a8e3920079a16263b578eaf7c3ba",
-                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/06f211dfffff18d91844c1f55250d5d13c007e18",
+                "reference": "06f211dfffff18d91844c1f55250d5d13c007e18",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-mbstring": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "conflict": {
                 "zendframework/zend-escaper": "*"
             },
             "require-dev": {
-                "infection/infection": "^0.29.8",
-                "laminas/laminas-coding-standard": "~3.0.1",
-                "phpunit/phpunit": "^10.5.45",
-                "psalm/plugin-phpunit": "^0.19.2",
-                "vimeo/psalm": "^6.6.2"
+                "infection/infection": "^0.31.0",
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "type": "library",
             "autoload": {
@@ -209,7 +209,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-05-06T19:29:36+00:00"
+            "time": "2025-10-14T18:31:13+00:00"
         },
         {
             "name": "laminas/laminas-httphandlerrunner",
@@ -280,22 +280,23 @@
         },
         {
             "name": "laminas/laminas-stratigility",
-            "version": "3.13.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stratigility.git",
-                "reference": "3df57528b5c8e9d958515c51006825a83f76d62b"
+                "reference": "3413771ac42d096a108236f2790bba6803df8a27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/3df57528b5c8e9d958515c51006825a83f76d62b",
-                "reference": "3df57528b5c8e9d958515c51006825a83f76d62b",
+                "url": "https://api.github.com/repos/laminas/laminas-stratigility/zipball/3413771ac42d096a108236f2790bba6803df8a27",
+                "reference": "3413771ac42d096a108236f2790bba6803df8a27",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",
                 "laminas/laminas-escaper": "^2.10.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/http-factory": "^1.0.2",
                 "psr/http-message": "^1.0 || ^2.0",
                 "psr/http-server-middleware": "^1.0.2"
             },
@@ -303,14 +304,15 @@
                 "zendframework/zend-stratigility": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-diactoros": "^2.25 || ^3.5.0",
-                "phpunit/phpunit": "^10.5.37",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "laminas/laminas-coding-standard": "~3.1.0",
+                "laminas/laminas-diactoros": "^2.25 || ^3.8.0",
+                "phpunit/phpunit": "^11.5.42",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.13.1"
             },
             "suggest": {
-                "psr/http-message-implementation": "Please install a psr/http-message-implementation to consume Stratigility; e.g., laminas/laminas-diactoros"
+                "psr/http-factory-implementation": "Please install a psr/http-factory implementation to consume Stratigility; e.g., laminas/laminas-diactoros",
+                "psr/http-message-implementation": "Please install a psr/http-message implementation to consume Stratigility; e.g., laminas/laminas-diactoros"
             },
             "type": "library",
             "autoload": {
@@ -318,11 +320,7 @@
                     "src/functions/double-pass-middleware.php",
                     "src/functions/host.php",
                     "src/functions/middleware.php",
-                    "src/functions/path.php",
-                    "src/functions/double-pass-middleware.legacy.php",
-                    "src/functions/host.legacy.php",
-                    "src/functions/middleware.legacy.php",
-                    "src/functions/path.legacy.php"
+                    "src/functions/path.php"
                 ],
                 "psr-4": {
                     "Laminas\\Stratigility\\": "src/"
@@ -339,6 +337,7 @@
                 "laminas",
                 "middleware",
                 "psr-15",
+                "psr-17",
                 "psr-7"
             ],
             "support": {
@@ -355,7 +354,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-28T11:28:41+00:00"
+            "time": "2025-10-14T20:48:06+00:00"
         },
         {
             "name": "mezzio/mezzio-router",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.5.1@3f17a6b24a2dbe543e21408c2b19108cf6a355ef">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
   <file src="src/Application.php">
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$middleware]]></code>
@@ -40,9 +40,6 @@
     </UndefinedClass>
   </file>
   <file src="src/Container/ErrorHandlerFactory.php">
-    <InvalidArgument>
-      <code><![CDATA[$container->get(ResponseInterface::class)]]></code>
-    </InvalidArgument>
     <PossiblyInvalidArgument>
       <code><![CDATA[$generator]]></code>
     </PossiblyInvalidArgument>
@@ -331,11 +328,6 @@
     <MixedAssignment>
       <code><![CDATA[$received]]></code>
     </MixedAssignment>
-  </file>
-  <file src="test/Response/CallableResponseFactoryDecoratorTest.php">
-    <InternalMethod>
-      <code><![CDATA[new CallableResponseFactoryDecorator(fn(): ResponseInterface => $this->response)]]></code>
-    </InternalMethod>
   </file>
   <file src="test/Router/IntegrationTest.php">
     <ArgumentTypeCoercion>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -24,17 +24,6 @@
                 <referencedClass name="Mezzio\Response\CallableResponseFactoryDecorator"/>
             </errorLevel>
         </DeprecatedClass>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="Mezzio\Response\CallableResponseFactoryDecorator::createResponse"/>
-                <referencedMethod name="Mezzio\Response\CallableResponseFactoryDecorator::getResponseFromCallable"/>
-            </errorLevel>
-        </InternalMethod>
-        <InternalClass>
-            <errorLevel type="suppress">
-                <referencedClass name="Mezzio\Response\CallableResponseFactoryDecorator"/>
-            </errorLevel>
-        </InternalClass>
         <DeprecatedTrait>
             <errorLevel type="suppress">
                 <file name="src/Container/NotFoundHandlerFactory.php"/>

--- a/src/Container/ErrorHandlerFactory.php
+++ b/src/Container/ErrorHandlerFactory.php
@@ -6,6 +6,7 @@ namespace Mezzio\Container;
 
 use Laminas\Stratigility\Middleware\ErrorHandler;
 use Mezzio\Middleware\ErrorResponseGenerator;
+use Mezzio\Response\CallableResponseFactoryDecorator;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -20,6 +21,9 @@ class ErrorHandlerFactory
                 ? $container->get(\Zend\Expressive\Middleware\ErrorResponseGenerator::class)
                 : null);
 
-        return new ErrorHandler($container->get(ResponseInterface::class), $generator);
+        /** @var callable():ResponseInterface $responseFactory */
+        $responseFactory = $container->get(ResponseInterface::class);
+
+        return new ErrorHandler(new CallableResponseFactoryDecorator($responseFactory), $generator);
     }
 }

--- a/src/Response/CallableResponseFactoryDecorator.php
+++ b/src/Response/CallableResponseFactoryDecorator.php
@@ -10,6 +10,9 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @internal
  * @deprecated Will be removed with v4.0.0
+ *
+ * @psalm-internal Mezzio
+ * @psalm-internal MezzioTest
  */
 final class CallableResponseFactoryDecorator implements ResponseFactoryInterface
 {

--- a/test/Container/ErrorHandlerFactoryTest.php
+++ b/test/Container/ErrorHandlerFactoryTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace MezzioTest\Container;
 
+use Laminas\Diactoros\Response;
 use Laminas\Stratigility\Middleware\ErrorHandler;
 use Laminas\Stratigility\Middleware\ErrorResponseGenerator as StratigilityGenerator;
 use Mezzio\Container\ErrorHandlerFactory;
 use Mezzio\Middleware\ErrorResponseGenerator;
+use Mezzio\Response\CallableResponseFactoryDecorator;
 use MezzioTest\InMemoryContainer;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -43,20 +45,25 @@ final class ErrorHandlerFactoryTest extends TestCase
 
     public function testFactoryCreatesHandlerWithStratigilityGeneratorIfNoGeneratorServiceAvailable(): void
     {
-        $responseFactory = static function (): void {
+        $responseFactory = static function (): ResponseInterface {
+            return new Response();
         };
         $this->container->set(ResponseInterface::class, $responseFactory);
 
         $factory = new ErrorHandlerFactory();
         $handler = $factory($this->container);
 
-        self::assertEquals(new ErrorHandler($responseFactory, new StratigilityGenerator()), $handler);
+        self::assertEquals(
+            new ErrorHandler(new CallableResponseFactoryDecorator($responseFactory), new StratigilityGenerator()),
+            $handler,
+        );
     }
 
     public function testFactoryCreatesHandlerWithGeneratorIfGeneratorServiceAvailable(): void
     {
         $generator       = $this->createMock(ErrorResponseGenerator::class);
-        $responseFactory = static function (): void {
+        $responseFactory = static function (): ResponseInterface {
+            return new Response();
         };
 
         $this->container->set(ErrorResponseGenerator::class, $generator);
@@ -65,6 +72,9 @@ final class ErrorHandlerFactoryTest extends TestCase
         $factory = new ErrorHandlerFactory();
         $handler = $factory($this->container);
 
-        self::assertEquals(new ErrorHandler($responseFactory, $generator), $handler);
+        self::assertEquals(
+            new ErrorHandler(new CallableResponseFactoryDecorator($responseFactory), $generator),
+            $handler,
+        );
     }
 }


### PR DESCRIPTION
Constructor for the `Laminas\Stratigility\Middleware\ErrorHandler` switched from using callable response factory to PSR http factory.

`ErrorHandler` factory can support both laminas-stratigility v3 and v4 but it would require using reflection. Considering very limited BC impact introduced by stratigility v4 I see no reason to keep both versions.

Mezzio currently does not support PSR http factory which would require a new major release. This PR does not introduce such support. Internal callable response factory decorator provides compatibility instead.

laminas-stratigility v3 does not provide php 8.5 support. This change will make this package installable on PHP 8.5. Related to #221 