### PR TITLE
Add support for `mezzio-template@3.0`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 /phpcs.xml export-ignore
 /phpunit.xml.dist export-ignore
 .psr-container.php.stub export-ignore
+/lychee.toml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,4 @@
 /phpunit.xml.dist export-ignore
 .psr-container.php.stub export-ignore
 /lychee.toml export-ignore
+/Makefile export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /clover.xml
-/coveralls-upload.json
 /docs/html/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
@@ -7,3 +6,4 @@
 /vendor/
 /.phpunit.cache
 /.phpcs-cache
+/.markdownlint.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,98 @@
+# Run `make` (no arguments) to get a short description of what is available
+# within this `Makefile`.
+
+SHELL=/bin/bash
+MKDOCS_IMAGE_ID := $(shell docker images -q laminas/mkdocs | xargs)
+DOCKER_PHP=-it -w /app -v ${PWD}:/app --rm php:8.2-alpine
+MDLINT_FILE = https://raw.githubusercontent.com/laminas/laminas-continuous-integration-action/e321dbdcc74e665512b5d2e8fd9012b3432df897/setup/markdownlint/markdownlint.json
+
+MK_BLUE = echo -e "\033[34m"$(1)"\033[0m"
+MK_GREEN = echo -e "\033[32m"$(1)"\033[0m"
+
+MK_INFO = @$(call MK_BLUE,$1)
+MK_SUCCESS = @$(call MK_GREEN,$1)
+
+help: ## shows this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_\-\.]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+.PHONY: help
+
+docs-lint: .markdownlint.json ## Lint documentation
+	@$(call MK_INFO,"Linting documentation files")
+	@docker run -it -w /app -v ${PWD}:/app --rm davidanson/markdownlint-cli2 "docs/**/*.md" README.md
+.PHONY: docs-lint
+
+check-links: ## Check documentation links
+	@$(call MK_INFO,"Checking links in documentation files")
+	@docker run -it -w /app -v ${PWD}:/app --rm lycheeverse/lychee "docs/**/*.md" README.md
+.PHONY: check-links
+
+.markdownlint.json: ## Fetch the most recent settings for Markdown lint
+	@$(call MK_INFO,"Fetching markdown lint configuration")
+	@curl -o .markdownlint.json ${MDLINT_FILE}
+
+install: ## Install composer dependencies
+	@$(call MK_INFO,"Installing composer dependencies")
+	@composer install
+.PHONY: install
+
+documentation-theme: ## fetch the documentation theme repo
+	@$(call MK_INFO,"Fetching documentation theme resources")
+	@git clone git@github.com:laminas/documentation-theme.git
+
+build-mkdocs-image: documentation-theme ## Build the mkdocs image with necessary dependencies for building the docs
+	@$(if ${MKDOCS_IMAGE_ID}, @$(call MK_INFO,"mkdocs image already built"), cd documentation-theme/builder && docker build -t laminas/mkdocs .)
+.PHONY: build-mkdocs-image
+
+docs: build-mkdocs-image ## build the docs using a Docker container
+	@$(call MK_INFO,"Building documentation")
+	@docker run -it -w /app -v ${PWD}:/app --rm laminas/mkdocs ./documentation-theme/build.sh -u https://www.example.com
+	@$(call MK_SUCCESS,"file://${PWD}/docs/html/index.html")
+.PHONY: docs
+
+set-baseline: ## Expand the Psalm baseline with current issues
+	@$(call MK_INFO,"Resetting the Psalm baseline")
+	@docker run $(DOCKER_PHP) vendor/bin/psalm --no-cache --set-baseline=psalm-baseline.xml
+.PHONY: set-baseline
+
+update-baseline: ## Remove resolved issues from the baseline
+	@$(call MK_INFO,"Updating the Psalm baseline")
+	@docker run $(DOCKER_PHP) vendor/bin/psalm --no-cache --update-baseline
+.PHONY: update-baseline
+
+sa: ## Run static analysis
+	@$(call MK_INFO,"Running static analysis")
+	@docker run $(DOCKER_PHP) vendor/bin/psalm --no-cache
+.PHONY: sa
+
+cs: ## Run coding standards checks
+	@$(call MK_INFO,"Checking coding standards")
+	@docker run $(DOCKER_PHP) vendor/bin/phpcs
+.PHONY: cs
+
+test: ## Run tests
+	@$(call MK_INFO,"Running Tests")
+	@docker run $(DOCKER_PHP) vendor/bin/phpunit
+.PHONY: test
+
+composer-checks: ## Dump the composer autoloader
+	@$(call MK_INFO,"Validating composer.json and dumping the autoloader")
+	@composer validate --strict
+	@composer dump-autoload --strict-psr --optimize
+.PHONY: composer-checks
+
+qa: composer-checks cs test sa docs-lint check-links ## Run all QA checks
+
+bump: ## Update dependencies and bump development dependency versions
+	@$(call MK_INFO,"Bumping development dependencies and refreshing composer lock")
+	@composer update
+	@composer bump -D
+	@composer update
+.PHONY: bump
+
+clean: ## Delete caches and docs-build assets
+	@$(call MK_INFO,"Cleaning up")
+	@rm -rf documentation-theme
+	@rm -rf docs/html
+	@rm -f .phpcs-cache
+	@rm -f .phpunit.result.cache
+	@rm -rf .phpunit.cache

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ features:
   Middleware matched via routing is retrieved from the composed container.
 - Optionally, templating. We support:
     - [Plates](http://platesphp.com/)
-    - [Twig](http://twig.sensiolabs.org/)
+    - [Twig](https://twig.symfony.com/)
     - [Laminas's PhpRenderer](https://github.com/laminas/laminas-view)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "laminas/laminas-httphandlerrunner": "^2.1",
         "laminas/laminas-stratigility": "^4.3",
         "mezzio/mezzio-router": "^3.15.0",
-        "mezzio/mezzio-template": "^2.2",
+        "mezzio/mezzio-template": "^2.2 || ^3.0",
         "psr/container": "^1.0||^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0.1 || ^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -53,10 +53,10 @@
         "filp/whoops": "^2.18.4",
         "laminas/laminas-coding-standard": "^3.1.0",
         "laminas/laminas-diactoros": "^3.8.0",
-        "laminas/laminas-servicemanager": "^3.23.1",
+        "laminas/laminas-servicemanager": "^3.24.0",
         "mezzio/mezzio-fastroute": "^3.14",
         "mezzio/mezzio-laminasrouter": "^3.12",
-        "phpunit/phpunit": "^11.5.42",
+        "phpunit/phpunit": "^11.5.43",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.13.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24b031b70e73b57b2aac1ecb8cc01bbe",
+    "content-hash": "a95951d02e23d0edf563cbae3b92c255",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -440,16 +440,16 @@
         },
         {
             "name": "mezzio/mezzio-template",
-            "version": "2.13.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-template.git",
-                "reference": "ad72bb31036d0639a5c5a502af234217faf6932f"
+                "reference": "49a797e19b167b208327854c81eb079937f0b161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/ad72bb31036d0639a5c5a502af234217faf6932f",
-                "reference": "ad72bb31036d0639a5c5a502af234217faf6932f",
+                "url": "https://api.github.com/repos/mezzio/mezzio-template/zipball/49a797e19b167b208327854c81eb079937f0b161",
+                "reference": "49a797e19b167b208327854c81eb079937f0b161",
                 "shasum": ""
             },
             "require": {
@@ -500,7 +500,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-10-11T08:45:28+00:00"
+            "time": "2025-10-11T09:18:27+00:00"
         },
         {
             "name": "psr/container",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d73d3e00b3048d16eb170495c8b01f87",
+    "content-hash": "24b031b70e73b57b2aac1ecb8cc01bbe",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -773,16 +773,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "541057574806f942c94662b817a50f63f7345360"
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/541057574806f942c94662b817a50f63f7345360",
-                "reference": "541057574806f942c94662b817a50f63f7345360",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
+                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
                 "shasum": ""
             },
             "require": {
@@ -825,9 +825,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
             },
-            "time": "2025-10-20T12:43:39+00:00"
+            "time": "2025-10-29T15:56:20+00:00"
         }
     ],
     "packages-dev": [
@@ -4204,16 +4204,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.42",
+            "version": "11.5.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1c6cb5dfe412af3d0dfd414cfd110e3b9cfdbc3c"
+                "reference": "c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1c6cb5dfe412af3d0dfd414cfd110e3b9cfdbc3c",
-                "reference": "1c6cb5dfe412af3d0dfd414cfd110e3b9cfdbc3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924",
+                "reference": "c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924",
                 "shasum": ""
             },
             "require": {
@@ -4285,7 +4285,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.42"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.43"
             },
             "funding": [
                 {
@@ -4309,7 +4309,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-28T12:09:13+00:00"
+            "time": "2025-10-30T08:39:39+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -5748,16 +5748,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.4",
+            "version": "v7.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db"
+                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
-                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
+                "reference": "cdb80fa5869653c83cfe1a9084a673b6daf57ea7",
                 "shasum": ""
             },
             "require": {
@@ -5822,7 +5822,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.4"
+                "source": "https://github.com/symfony/console/tree/v7.3.5"
             },
             "funding": [
                 {
@@ -5842,7 +5842,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-22T15:31:00+00:00"
+            "time": "2025-10-14T15:46:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,1 @@
+exclude = ['^http://localhost']

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -45,22 +45,18 @@
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Container/ErrorResponseGeneratorFactory.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$layout]]></code>
+    </ArgumentTypeCoercion>
     <MixedArgument>
-      <code><![CDATA[$debug]]></code>
       <code><![CDATA[$errorHandlerConfig]]></code>
-      <code><![CDATA[$template]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$errorHandlerConfig['template_error']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
-      <code><![CDATA[$debug]]></code>
       <code><![CDATA[$errorHandlerConfig]]></code>
-      <code><![CDATA[$template]]></code>
     </MixedAssignment>
-    <PossiblyInvalidArgument>
-      <code><![CDATA[$renderer]]></code>
-    </PossiblyInvalidArgument>
   </file>
   <file src="src/Container/FilterUsingXForwardedHeadersFactory.php">
     <MixedArrayAccess>

--- a/src/Container/ErrorResponseGeneratorFactory.php
+++ b/src/Container/ErrorResponseGeneratorFactory.php
@@ -10,6 +10,9 @@ use Psr\Container\ContainerInterface;
 use Webmozart\Assert\Assert;
 
 use function array_key_exists;
+use function assert;
+use function is_bool;
+use function is_string;
 
 /** @final */
 class ErrorResponseGeneratorFactory
@@ -19,22 +22,27 @@ class ErrorResponseGeneratorFactory
         $config = $container->has('config') ? $container->get('config') : [];
         Assert::isArrayAccessible($config);
 
-        $debug               = $config['debug'] ?? false;
+        $debug = $config['debug'] ?? false;
+        assert(is_bool($debug));
+
         $mezzioConfiguration = $config['mezzio'] ?? [];
         Assert::isMap($mezzioConfiguration);
 
         $errorHandlerConfig = $mezzioConfiguration['error_handler'] ?? [];
 
         $template = $errorHandlerConfig['template_error'] ?? ErrorResponseGenerator::TEMPLATE_DEFAULT;
-        $layout   = array_key_exists('layout', $errorHandlerConfig)
+        assert(is_string($template) && $template !== '');
+
+        $layout = array_key_exists('layout', $errorHandlerConfig)
             ? (string) $errorHandlerConfig['layout']
             : ErrorResponseGenerator::LAYOUT_DEFAULT;
 
         $renderer = $container->has(TemplateRendererInterface::class)
             ? $container->get(TemplateRendererInterface::class)
-            : ($container->has(\Zend\Expressive\Template\TemplateRendererInterface::class)
-                ? $container->get(\Zend\Expressive\Template\TemplateRendererInterface::class)
+            : ($container->has('Zend\Expressive\Template\TemplateRendererInterface')
+                ? $container->get('Zend\Expressive\Template\TemplateRendererInterface')
                 : null);
+        assert($renderer instanceof TemplateRendererInterface || $renderer === null);
 
         return new ErrorResponseGenerator($debug, $renderer, $template, $layout);
     }

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -25,6 +25,7 @@ class NotFoundHandler implements RequestHandlerInterface
 
     /**
      * @todo Allow nullable $layout
+     * @param non-empty-string $template
      * @param callable|ResponseFactoryInterface $responseFactory
      * @psalm-param (callable():ResponseInterface)|ResponseFactoryInterface $responseFactory
      */

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -21,6 +21,8 @@ class ErrorResponseGenerator
 
     /**
      * @todo Allow nullable $layout
+     * @param non-empty-string $template
+     * @param non-empty-string $layout
      */
     public function __construct(
         bool $isDevelopmentMode = false,

--- a/src/Response/ErrorResponseGeneratorTrait.php
+++ b/src/Response/ErrorResponseGeneratorTrait.php
@@ -34,7 +34,7 @@ EOT;
     /**
      * Name of the template to render.
      *
-     * @var string
+     * @var non-empty-string
      */
     private $template;
 
@@ -45,6 +45,9 @@ EOT;
      */
     private $layout;
 
+    /**
+     * @param array<non-empty-string, mixed> $templateData
+     */
     private function prepareTemplatedResponse(
         Throwable $e,
         TemplateRendererInterface $renderer,

--- a/src/Response/ServerRequestErrorResponseGenerator.php
+++ b/src/Response/ServerRequestErrorResponseGenerator.php
@@ -27,6 +27,7 @@ class ServerRequestErrorResponseGenerator
 
     /**
      * @param (callable():ResponseInterface)|ResponseFactoryInterface $responseFactory
+     * @param non-empty-string $template
      */
     public function __construct(
         $responseFactory,

--- a/test/Container/EmitterFactoryTest.php
+++ b/test/Container/EmitterFactoryTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Mezzio\Container;
+namespace MezzioTest\Container;
 
 use Laminas\HttpHandlerRunner\Emitter\EmitterStack;
 use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use Mezzio\Container\EmitterFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 

--- a/test/Container/ErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ErrorResponseGeneratorFactoryTest.php
@@ -87,6 +87,7 @@ final class ErrorResponseGeneratorFactoryTest extends TestCase
 
         // ideally we would like to keep null there,
         // but right now ErrorResponseGeneratorFactory does not accept null for layout
+        /** @psalm-suppress InvalidArgument */
         self::assertEquals(new ErrorResponseGenerator(false, null, 'error::custom', ''), $generator);
     }
 

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -18,14 +18,9 @@ use RuntimeException;
 
 final class ErrorResponseGeneratorTest extends TestCase
 {
-    /** @var ServerRequestInterface&MockObject */
-    private $request;
-
-    /** @var StreamInterface&MockObject */
-    private $stream;
-
-    /** @var TemplateRendererInterface&MockObject */
-    private $renderer;
+    private ServerRequestInterface&MockObject $request;
+    private StreamInterface&MockObject $stream;
+    private TemplateRendererInterface&MockObject $renderer;
 
     public function setUp(): void
     {
@@ -97,7 +92,7 @@ final class ErrorResponseGeneratorTest extends TestCase
         $this->assertSame($response, $secondaryResponse);
     }
 
-    /** @return array<string, array{0:string|null, 1: string}> */
+    /** @return array<string, array{0:non-empty-string|null, 1: non-empty-string}> */
     public static function templates(): array
     {
         return [
@@ -106,6 +101,7 @@ final class ErrorResponseGeneratorTest extends TestCase
         ];
     }
 
+    /** @param non-empty-string $template */
     #[DataProvider('templates')]
     public function testRendersTemplateWithoutErrorDetailsWhenRendererPresentAndNotInDebugMode(
         ?string $template,
@@ -155,6 +151,7 @@ final class ErrorResponseGeneratorTest extends TestCase
         $this->assertSame($response, $secondaryResponse);
     }
 
+    /** @param non-empty-string $template */
     #[DataProvider('templates')]
     public function testRendersTemplateWithErrorDetailsWhenRendererPresentAndInDebugMode(
         ?string $template,


### PR DESCRIPTION
Requires a number of type refinements but otherwise, `mezzio` can support either v2 or v3 of `mezzio-template`

This branch is cut from #232 - so that will need merging first. After that, I can rebase.