### PR TITLE
refactor: enforce strict typing by rector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,4 @@
 .psr-container.php.stub export-ignore
 /lychee.toml export-ignore
 /Makefile export-ignore
+/rector.php export-ignore

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,6 +6,22 @@ on:
     branches:
     tags:
 
+env:
+  default_php: 8.2
+
 jobs:
   ci:
     uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x
+
+  rector:
+    runs-on: ubuntu-latest
+    name: Run Rector on PHP
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: shivammathur/setup-php@2.34.1
+        with:
+          php-version: ${{ env.default_php }}
+          extensions: swoole
+          tools: composer
+      - uses: ramsey/composer-install@v3
+      - run: composer rector

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "mezzio/mezzio-laminasrouter": "^3.12",
         "phpunit/phpunit": "^11.5.44",
         "psalm/plugin-phpunit": "^0.19.5",
+        "rector/rector": "^2.4",
         "vimeo/psalm": "^6.13.1"
     },
     "conflict": {
@@ -100,6 +101,8 @@
         ],
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
+        "rector": "rector -n",
+        "rector:fix": "rector",
         "static-analysis": "psalm --shepherd --stats",
         "update-baseline": "psalm --update-baseline",
         "test": "phpunit --colors=always",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea6a26ac460e2e77053f5c0af4b5d6f4",
+    "content-hash": "bb33cc61045cfce75e5849c4f3070c0e",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -3879,6 +3879,59 @@
             "time": "2025-08-30T15:50:23+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "2.1.54",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-29T13:31:09+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "11.0.12",
             "source": {
@@ -4429,6 +4482,66 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.48"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-16T13:07:34+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -6816,5 +6929,5 @@
     "platform-overrides": {
         "php": "8.2.99"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,6 +15,7 @@
     <file>bin</file>
     <file>src</file>
     <file>test</file>
+    <file>rector.php</file>
 
     <!-- Include all rules from the Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard"/>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -196,28 +196,6 @@
       <code><![CDATA[$this->container->get(ResponseInterface::class)]]></code>
     </InvalidArgument>
   </file>
-  <file src="test/Container/RequestHandlerRunnerFactoryTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$errorGenerator]]></code>
-    </InvalidArgument>
-    <InvalidFunctionCall>
-      <code><![CDATA[$errorGenerator($e)]]></code>
-    </InvalidFunctionCall>
-    <MixedArgument>
-      <code><![CDATA[ApplicationPipeline::class]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$toTest]]></code>
-      <code><![CDATA[$toTest]]></code>
-    </MixedAssignment>
-    <MixedFunctionCall>
-      <code><![CDATA[$toTest($e)]]></code>
-      <code><![CDATA[$toTest()]]></code>
-    </MixedFunctionCall>
-    <UndefinedClass>
-      <code><![CDATA[ApplicationPipeline]]></code>
-    </UndefinedClass>
-  </file>
   <file src="test/Container/ResponseFactoryFactoryTest.php">
     <RedundantCondition>
       <code><![CDATA[assertIsCallable]]></code>
@@ -289,11 +267,6 @@
       <code><![CDATA[$this->services[$id]]]></code>
     </MixedReturnStatement>
   </file>
-  <file src="test/Middleware/ErrorResponseGeneratorTest.php">
-    <MixedArgument>
-      <code><![CDATA[$body]]></code>
-    </MixedArgument>
-  </file>
   <file src="test/Middleware/WhoopsErrorResponseGeneratorTest.php">
     <InvalidArgument>
       <code><![CDATA[$whoops]]></code>
@@ -348,21 +321,5 @@
     <ParamNameMismatch>
       <code><![CDATA[$delegate]]></code>
     </ParamNameMismatch>
-  </file>
-  <file src="test/TestAsset/InvokableMiddleware.php">
-    <MissingParamType>
-      <code><![CDATA[$next]]></code>
-      <code><![CDATA[$next]]></code>
-      <code><![CDATA[$request]]></code>
-      <code><![CDATA[$request]]></code>
-      <code><![CDATA[$response]]></code>
-      <code><![CDATA[$response]]></code>
-    </MissingParamType>
-    <MissingReturnType>
-      <code><![CDATA[staticallyCallableMiddleware]]></code>
-    </MissingReturnType>
-    <MixedMethodCall>
-      <code><![CDATA[withHeader]]></code>
-    </MixedMethodCall>
   </file>
 </files>

--- a/rector.php
+++ b/rector.php
@@ -13,5 +13,6 @@ return RectorConfig::configure()
     ])
     ->withPreparedSets(
         typeDeclarations: true,
+        privatization: true,
     )
     ->withSkipPath(__DIR__ . '/test/TestAsset');

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPhpSets(php82: true)
+    ->withAttributesSets()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+    ])
+    ->withPreparedSets(
+        typeDeclarations: true,
+    )
+    ->withSkipPath(__DIR__ . '/test/TestAsset');

--- a/src/Application.php
+++ b/src/Application.php
@@ -127,7 +127,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
      *     those types) to associate with route.
      * @param null|non-empty-string $name The name of the route.
      */
-    public function post(string $path, $middleware, $name = null): Router\Route
+    public function post(string $path, $middleware, ?string $name = null): Router\Route
     {
         return $this->route($path, $middleware, ['POST'], $name);
     }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -28,16 +28,13 @@ use function strtoupper;
 /** @psalm-import-type MiddlewareParam from MiddlewareFactoryInterface */
 final class ApplicationTest extends TestCase
 {
-    /** @var MiddlewareFactoryInterface&MockObject */
-    private $factory;
+    private MiddlewareFactoryInterface&MockObject $factory;
 
-    /** @var MiddlewarePipeInterface&MockObject */
-    private $pipeline;
+    private MiddlewarePipeInterface&MockObject $pipeline;
 
     private RouteCollectorInterface&MockObject $routes;
 
-    /** @var RequestHandlerRunnerInterface&MockObject */
-    private $runner;
+    private RequestHandlerRunnerInterface&MockObject $runner;
 
     private Application $app;
 
@@ -106,10 +103,10 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testPipeCanAcceptSingleMiddlewareArgument($middleware): void
+    public function testPipeCanAcceptSingleMiddlewareArgument(mixed $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
         $this->factory->expects(self::once())
@@ -126,10 +123,10 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testPipeCanAcceptAPathArgument($middleware): void
+    public function testPipeCanAcceptAPathArgument(mixed $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
         $this->factory->expects(self::once())
@@ -156,10 +153,10 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testRouteAcceptsPathAndMiddlewareOnly($middleware): void
+    public function testRouteAcceptsPathAndMiddlewareOnly(mixed $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
 
@@ -184,10 +181,10 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testRouteAcceptsPathMiddlewareAndMethodsOnly($middleware): void
+    public function testRouteAcceptsPathMiddlewareAndMethodsOnly(mixed $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
 
@@ -212,10 +209,10 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testRouteAcceptsPathMiddlewareMethodsAndName($middleware): void
+    public function testRouteAcceptsPathMiddlewareMethodsAndName(mixed $middleware): void
     {
         $preparedMiddleware = $this->createMockMiddleware();
 
@@ -307,11 +304,12 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testAnyMethodPassesNullForMethodWhenNoNamePresent($middleware): void
-    {
+    public function testAnyMethodPassesNullForMethodWhenNoNamePresent(
+        mixed $middleware,
+    ): void {
         $preparedMiddleware = $this->createMockMiddleware();
 
         $this->factory->expects(self::once())
@@ -335,11 +333,12 @@ final class ApplicationTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('validMiddleware')]
-    public function testAnyMethodPassesNullForMethodWhenAllArgumentsPresent($middleware): void
-    {
+    public function testAnyMethodPassesNullForMethodWhenAllArgumentsPresent(
+        mixed $middleware,
+    ): void {
         $preparedMiddleware = $this->createMockMiddleware();
 
         $this->factory->expects(self::once())

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -45,8 +45,7 @@ final class ApplicationConfigInjectionDelegatorTest extends TestCase
 
     private RouteCollector $routeCollector;
 
-    /** @var RouterInterface&MockObject */
-    private $router;
+    private RouterInterface&MockObject $router;
 
     public function setUp(): void
     {
@@ -139,7 +138,7 @@ final class ApplicationConfigInjectionDelegatorTest extends TestCase
         Assert::assertThat($found, Assert::isTrue(), $message);
     }
 
-    /** @return list<array{MiddlewareParam}> */
+    /** @psalm-return list<array{MiddlewareParam}> */
     public static function callableMiddlewares(): array
     {
         return [
@@ -149,7 +148,7 @@ final class ApplicationConfigInjectionDelegatorTest extends TestCase
                     ServerRequestInterface $request,
                     RequestHandlerInterface $handler): ResponseInterface => new Response(),
             ],
-            [[InvokableMiddleware::class, 'staticallyCallableMiddleware']],
+            [InvokableMiddleware::staticallyCallableMiddleware(...)],
         ];
     }
 
@@ -163,10 +162,10 @@ final class ApplicationConfigInjectionDelegatorTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+     * @psalm-param MiddlewareParam $middleware
      */
     #[DataProvider('callableMiddlewares')]
-    public function testInjectRoutesFromConfigSetsUpRoutesFromConfig($middleware): void
+    public function testInjectRoutesFromConfigSetsUpRoutesFromConfig(mixed $middleware): void
     {
         $this->container->set('HelloWorld', true);
         $this->container->set('Ping', true);
@@ -465,7 +464,7 @@ final class ApplicationConfigInjectionDelegatorTest extends TestCase
         $this->container->set('config', $config);
 
         $delegator   = new ApplicationConfigInjectionDelegator();
-        $application = $delegator($this->container, '', fn() => $this->createApplication());
+        $application = $delegator($this->container, '', fn(): Application => $this->createApplication());
 
         $this->assertCount(1, $application->getRoutes());
     }

--- a/test/Container/ErrorHandlerFactoryTest.php
+++ b/test/Container/ErrorHandlerFactoryTest.php
@@ -45,9 +45,7 @@ final class ErrorHandlerFactoryTest extends TestCase
 
     public function testFactoryCreatesHandlerWithStratigilityGeneratorIfNoGeneratorServiceAvailable(): void
     {
-        $responseFactory = static function (): ResponseInterface {
-            return new Response();
-        };
+        $responseFactory = static fn(): ResponseInterface => new Response();
         $this->container->set(ResponseInterface::class, $responseFactory);
 
         $factory = new ErrorHandlerFactory();
@@ -62,9 +60,7 @@ final class ErrorHandlerFactoryTest extends TestCase
     public function testFactoryCreatesHandlerWithGeneratorIfGeneratorServiceAvailable(): void
     {
         $generator       = $this->createMock(ErrorResponseGenerator::class);
-        $responseFactory = static function (): ResponseInterface {
-            return new Response();
-        };
+        $responseFactory = static fn(): ResponseInterface => new Response();
 
         $this->container->set(ErrorResponseGenerator::class, $generator);
         $this->container->set(ResponseInterface::class, $responseFactory);

--- a/test/Container/ErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ErrorResponseGeneratorFactoryTest.php
@@ -16,8 +16,7 @@ final class ErrorResponseGeneratorFactoryTest extends TestCase
 {
     private InMemoryContainer $container;
 
-    /** @var TemplateRendererInterface&MockObject */
-    private $renderer;
+    private TemplateRendererInterface&MockObject $renderer;
 
     public function setUp(): void
     {

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -23,8 +23,7 @@ final class NotFoundHandlerFactoryTest extends TestCase
 {
     private InMemoryContainer $container;
 
-    /** @var ResponseInterface&MockObject */
-    private $response;
+    private ResponseInterface&MockObject $response;
 
     private NotFoundHandlerFactory $factory;
 
@@ -32,7 +31,7 @@ final class NotFoundHandlerFactoryTest extends TestCase
     {
         $this->response  = $this->createMock(ResponseInterface::class);
         $this->container = new InMemoryContainer();
-        $this->container->set(ResponseInterface::class, fn() => $this->response);
+        $this->container->set(ResponseInterface::class, fn(): ResponseInterface&MockObject => $this->response);
         $this->factory = new NotFoundHandlerFactory();
     }
 

--- a/test/Container/RequestHandlerRunnerFactoryTest.php
+++ b/test/Container/RequestHandlerRunnerFactoryTest.php
@@ -6,7 +6,6 @@ namespace MezzioTest\Container;
 
 use Laminas\HttpHandlerRunner\Emitter\EmitterInterface;
 use Laminas\HttpHandlerRunner\RequestHandlerRunner;
-use Mezzio\ApplicationPipeline;
 use Mezzio\Container\RequestHandlerRunnerFactory;
 use Mezzio\Response\ServerRequestErrorResponseGenerator;
 use MezzioTest\InMemoryContainer;
@@ -28,22 +27,27 @@ final class RequestHandlerRunnerFactoryTest extends TestCase
         $handler              = $this->registerHandlerInContainer($container);
         $emitter              = $this->registerEmitterInContainer($container);
         $serverRequestFactory = $this->registerServerRequestFactoryInContainer($container);
-        $errorGenerator       = $this->registerServerRequestErrorResponseGeneratorInContainer($container);
+        /** @psalm-suppress NoValue */
+        $errorGenerator = $this->registerServerRequestErrorResponseGeneratorInContainer($container);
+        self::assertIsCallable($errorGenerator);
 
         $factory = new RequestHandlerRunnerFactory();
 
         $runner = $factory($container);
 
+        /** @psalm-suppress MixedArgumentTypeCoercion */
         self::assertEquals(
             new RequestHandlerRunner($handler, $emitter, $serverRequestFactory, $errorGenerator),
             $runner
         );
 
-        $r      = new ReflectionProperty($runner, 'serverRequestFactory');
+        $r = new ReflectionProperty($runner, 'serverRequestFactory');
+        /** @var callable():ServerRequestInterface $toTest */
         $toTest = $r->getValue($runner);
         $this->assertSame($serverRequestFactory(), $toTest());
 
-        $r      = new ReflectionProperty($runner, 'serverRequestErrorResponseGenerator');
+        $r = new ReflectionProperty($runner, 'serverRequestErrorResponseGenerator');
+        /** @var callable(Throwable):ResponseInterface $toTest */
         $toTest = $r->getValue($runner);
         $e      = new RuntimeException();
         $this->assertSame($errorGenerator($e), $toTest($e));
@@ -52,7 +56,7 @@ final class RequestHandlerRunnerFactoryTest extends TestCase
     public function registerHandlerInContainer(MutableMemoryContainerInterface $container): RequestHandlerInterface
     {
         $app = $this->createMock(RequestHandlerInterface::class);
-        $container->set(ApplicationPipeline::class, $app);
+        $container->set('Mezzio\\ApplicationPipeline', $app);
 
         return $app;
     }
@@ -78,10 +82,12 @@ final class RequestHandlerRunnerFactoryTest extends TestCase
     }
 
     /**
-     * @psalm-return MockObject&ServerRequestErrorResponseGenerator
+     * @psalm-suppress InvalidReturnType
+     * @psalm-suppress InvalidReturnStatement
      */
-    public function registerServerRequestErrorResponseGeneratorInContainer(MutableMemoryContainerInterface $container)
-    {
+    public function registerServerRequestErrorResponseGeneratorInContainer(
+        MutableMemoryContainerInterface $container,
+    ): MockObject&ServerRequestErrorResponseGenerator {
         $response  = $this->createMock(ResponseInterface::class);
         $generator = $this->createMock(ServerRequestErrorResponseGenerator::class);
         $generator->method('__invoke')

--- a/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Container;
 
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\ResponseFactoryFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -16,7 +17,7 @@ use function spl_autoload_unregister;
 
 final class ResponseFactoryFactoryWithoutDiactorosTest extends TestCase
 {
-    private ContainerInterface $container;
+    private ContainerInterface&MockObject $container;
 
     private ResponseFactoryFactory $factory;
 

--- a/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
@@ -80,9 +80,7 @@ final class ServerRequestErrorResponseGeneratorFactoryTest extends TestCase
     {
         $container = new InMemoryContainer();
 
-        $responseFactory = function (): ResponseInterface {
-            return $this->createMock(ResponseInterface::class);
-        };
+        $responseFactory = fn(): ResponseInterface => $this->createMock(ResponseInterface::class);
         $container->set(ResponseInterface::class, $responseFactory);
 
         $generator = ($this->factory)($container);

--- a/test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/ServerRequestFactoryFactoryWithoutDiactorosTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Container;
 
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\ServerRequestFactoryFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -16,7 +17,7 @@ use function spl_autoload_unregister;
 
 final class ServerRequestFactoryFactoryWithoutDiactorosTest extends TestCase
 {
-    private ContainerInterface $container;
+    private ContainerInterface&MockObject $container;
 
     private ServerRequestFactoryFactory $factory;
 

--- a/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Container;
 
 use Mezzio\Container\Exception\InvalidServiceException;
 use Mezzio\Container\StreamFactoryFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
@@ -16,7 +17,7 @@ use function spl_autoload_unregister;
 
 final class StreamFactoryFactoryWithoutDiactorosTest extends TestCase
 {
-    private ContainerInterface $container;
+    private ContainerInterface&MockObject $container;
 
     private StreamFactoryFactory $factory;
 

--- a/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
@@ -15,8 +15,7 @@ final class WhoopsErrorResponseGeneratorFactoryTest extends TestCase
 {
     private InMemoryContainer $container;
 
-    /** @var RunInterface&MockObject */
-    private $whoops;
+    private RunInterface&MockObject $whoops;
 
     public function setUp(): void
     {

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -73,16 +73,14 @@ final class WhoopsFactoryTest extends TestCase
         $this->assertWhoopsContainsHandler(JsonResponseHandler::class, $result);
     }
 
-    /**
-     * @param bool  $showsTrace
-     * @param bool  $isAjaxOnly
-     * @param bool  $requestIsAjax
-     */
     #[DataProvider('provideConfig')]
     #[Depends('testWillInjectJsonResponseHandlerIfConfigurationExpectsIt')]
     #[BackupGlobals(true)]
-    public function testJsonResponseHandlerCanBeConfigured($showsTrace, $isAjaxOnly, $requestIsAjax): void
-    {
+    public function testJsonResponseHandlerCanBeConfigured(
+        bool $showsTrace,
+        bool $isAjaxOnly,
+        bool $requestIsAjax,
+    ): void {
         // Set for Whoops 2.x json handler detection
         if ($requestIsAjax) {
             $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -20,11 +20,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class NotFoundHandlerTest extends TestCase
 {
-    /** @var ResponseInterface&MockObject */
-    private $response;
+    private ResponseInterface&MockObject $response;
 
-    /** @var ResponseFactoryInterface&MockObject */
-    private $responseFactory;
+    private ResponseFactoryInterface&MockObject $responseFactory;
 
     public function setUp(): void
     {

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -79,7 +79,7 @@ final class ErrorResponseGeneratorTest extends TestCase
 
         $this->stream->expects(self::once())
             ->method('write')
-            ->with(self::callback(function ($body) use ($leaf, $branch, $error): bool {
+            ->with(self::callback(function (string $body) use ($leaf, $branch, $error): bool {
                 $this->assertStringContainsString($leaf->getTraceAsString(), $body);
                 $this->assertStringContainsString($branch->getTraceAsString(), $body);
                 $this->assertStringContainsString($error->getTraceAsString(), $body);

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -9,6 +9,7 @@ use Mezzio\Middleware\LazyLoadingMiddleware;
 use Mezzio\MiddlewareContainer;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -16,20 +17,20 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 final class LazyLoadingMiddlewareTest extends TestCase
 {
-    /** @var MiddlewareContainer&MockObject */
-    private $container;
+    private MiddlewareContainer $container;
 
-    /** @var ServerRequestInterface&MockObject */
-    private $request;
+    private ContainerInterface&MockObject $innerContainer;
 
-    /** @var RequestHandlerInterface&MockObject */
-    private $handler;
+    private ServerRequestInterface&MockObject $request;
+
+    private RequestHandlerInterface&MockObject $handler;
 
     public function setUp(): void
     {
-        $this->container = $this->createMock(MiddlewareContainer::class);
-        $this->request   = $this->createMock(ServerRequestInterface::class);
-        $this->handler   = $this->createMock(RequestHandlerInterface::class);
+        $this->innerContainer = $this->createMock(ContainerInterface::class);
+        $this->container      = new MiddlewareContainer($this->innerContainer);
+        $this->request        = $this->createMock(ServerRequestInterface::class);
+        $this->handler        = $this->createMock(RequestHandlerInterface::class);
     }
 
     public function buildLazyLoadingMiddleware(string $middlewareName): LazyLoadingMiddleware
@@ -46,7 +47,8 @@ final class LazyLoadingMiddlewareTest extends TestCase
             ->with($this->request, $this->handler)
             ->willReturn($response);
 
-        $this->container->method('get')->with('foo')->willReturn($middleware);
+        $this->innerContainer->method('has')->with('foo')->willReturn(true);
+        $this->innerContainer->method('get')->with('foo')->willReturn($middleware);
 
         $lazyloader = $this->buildLazyLoadingMiddleware('foo');
         $this->assertSame(
@@ -58,7 +60,8 @@ final class LazyLoadingMiddlewareTest extends TestCase
     public function testDoesNotCatchContainerExceptions(): void
     {
         $exception = new InvalidMiddlewareException();
-        $this->container->method('get')->with('foo')->willThrowException($exception);
+        $this->innerContainer->method('has')->with('foo')->willReturn(true);
+        $this->innerContainer->method('get')->with('foo')->willThrowException($exception);
 
         $lazyloader = $this->buildLazyLoadingMiddleware('foo');
         $this->expectException(InvalidMiddlewareException::class);

--- a/test/Middleware/WhoopsErrorResponseGeneratorTest.php
+++ b/test/Middleware/WhoopsErrorResponseGeneratorTest.php
@@ -24,17 +24,13 @@ use function method_exists;
 
 final class WhoopsErrorResponseGeneratorTest extends TestCase
 {
-    /** @var RunInterface&MockObject */
-    private $whoops;
+    private RunInterface&MockObject $whoops;
 
-    /** @var ServerRequestInterface&MockObject */
-    private $request;
+    private ServerRequestInterface&MockObject $request;
 
-    /** @var ResponseInterface&MockObject */
-    private $response;
+    private ResponseInterface&MockObject $response;
 
-    /** @var StreamInterface&MockObject */
-    private $stream;
+    private StreamInterface&MockObject $stream;
 
     public function setUp(): void
     {

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -16,8 +16,8 @@ use Mezzio\MiddlewareFactory;
 use Mezzio\MiddlewareFactoryInterface;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -30,14 +30,13 @@ use function iterator_to_array;
 /** @psalm-import-type MiddlewareParam from MiddlewareFactoryInterface */
 final class MiddlewareFactoryTest extends TestCase
 {
-    /** @var MiddlewareContainer&MockObject */
-    private $container;
+    private MiddlewareContainer $container;
 
     private MiddlewareFactory $factory;
 
     public function setUp(): void
     {
-        $this->container = $this->createMock(MiddlewareContainer::class);
+        $this->container = new MiddlewareContainer($this->createMock(ContainerInterface::class));
         $this->factory   = new MiddlewareFactory($this->container);
     }
 
@@ -175,12 +174,14 @@ final class MiddlewareFactoryTest extends TestCase
     }
 
     /**
-     * @param MiddlewareParam $middleware
+    /**
+     *
+     * @psalm-param MiddlewareParam $middleware
      * @param mixed $expected Expected type or value for use with assertion
      */
     #[DataProvider('validPrepareTypes')]
     public function testPipelineAllowsAnyTypeSupportedByPrepare(
-        $middleware,
+        mixed $middleware,
         string $assertion,
         mixed $expected
     ): void {

--- a/test/Response/CallableResponseFactoryDecoratorTest.php
+++ b/test/Response/CallableResponseFactoryDecoratorTest.php
@@ -11,8 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 
 final class CallableResponseFactoryDecoratorTest extends TestCase
 {
-    /** @var MockObject&ResponseInterface */
-    private $response;
+    private MockObject&ResponseInterface $response;
 
     private CallableResponseFactoryDecorator $factory;
 

--- a/test/Response/ServerRequestErrorResponseGeneratorTest.php
+++ b/test/Response/ServerRequestErrorResponseGeneratorTest.php
@@ -16,13 +16,11 @@ use RuntimeException;
 
 final class ServerRequestErrorResponseGeneratorTest extends TestCase
 {
-    /** @var TemplateRendererInterface&MockObject */
-    private $renderer;
+    private TemplateRendererInterface&MockObject $renderer;
 
-    /** @var ResponseInterface&MockObject */
-    private $response;
+    private ResponseInterface&MockObject $response;
 
-    private ResponseFactoryInterface $responseFactory;
+    private ResponseFactoryInterface&MockObject $responseFactory;
 
     public function setUp(): void
     {

--- a/test/Router/RouteCollectorDelegatorIntegrationTest.php
+++ b/test/Router/RouteCollectorDelegatorIntegrationTest.php
@@ -51,7 +51,7 @@ final class RouteCollectorDelegatorIntegrationTest extends TestCase
         $dependencies = $config['dependencies'] ?? [];
         assert(is_array($dependencies));
         /** @psalm-suppress MixedAssignment */
-        $dependencies['services'] = $dependencies['services'] ?? [];
+        $dependencies['services'] ??= [];
         assert(is_array($dependencies['services']));
         $dependencies['services']['config'] = $asArrayObject ? new ArrayObject($config) : $config;
         /** @psalm-var ServiceManagerConfiguration $dependencies */

--- a/test/TestAsset/InvokableMiddleware.php
+++ b/test/TestAsset/InvokableMiddleware.php
@@ -4,15 +4,21 @@ declare(strict_types=1);
 
 namespace MezzioTest\TestAsset;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
 final class InvokableMiddleware
 {
-    public function __invoke($request, $response, $next)
+    public function __invoke(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        return self::staticallyCallableMiddleware($request, $response, $next);
+        return self::staticallyCallableMiddleware($request, $handler);
     }
 
-    public static function staticallyCallableMiddleware($request, $response, $next)
-    {
-        return $response->withHeader('X-Invoked', self::class);
+    public static function staticallyCallableMiddleware(
+        ServerRequestInterface $request,
+        RequestHandlerInterface $handler
+    ): ResponseInterface {
+        return $handler->handle($request)->withHeader('X-Invoked', self::class);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR introduces strict typing enforcement using Rector.

- Adds Rector to the project and configures it to enforce strict typing rules.
- QA main for unit tests
