### PR TITLE
Fix: Correctly handle an empty array given to `MiddlewareFactory::pipeline()`

### DIFF
--- a/src/MiddlewareFactory.php
+++ b/src/MiddlewareFactory.php
@@ -12,7 +12,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-use function array_shift;
 use function count;
 use function is_array;
 use function is_callable;
@@ -106,11 +105,9 @@ class MiddlewareFactory implements MiddlewareFactoryInterface
     public function pipeline(...$middleware): MiddlewarePipe
     {
         // Allow passing arrays of middleware or individual lists of middleware
-        if (
-            is_array($middleware[0])
-            && count($middleware) === 1
-        ) {
-            $middleware = array_shift($middleware);
+        $firstArgument = $middleware[0] ?? null;
+        if (is_array($firstArgument) && count($middleware) === 1) {
+            $middleware = $firstArgument;
         }
 
         $pipeline = new MiddlewarePipe();

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest;
 
 use Closure;
 use Laminas\Diactoros\Response;
+use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stratigility\Middleware\CallableMiddlewareDecorator;
 use Laminas\Stratigility\Middleware\RequestHandlerMiddleware;
 use Laminas\Stratigility\MiddlewarePipe;
@@ -16,7 +17,6 @@ use Mezzio\MiddlewareFactory;
 use Mezzio\MiddlewareFactoryInterface;
 use Mezzio\Router\Middleware\DispatchMiddleware;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,13 +30,12 @@ use function iterator_to_array;
 /** @psalm-import-type MiddlewareParam from MiddlewareFactoryInterface */
 final class MiddlewareFactoryTest extends TestCase
 {
-    private MiddlewareContainer&MockObject $container;
-
+    private MiddlewareContainer $container;
     private MiddlewareFactory $factory;
 
     protected function setUp(): void
     {
-        $this->container = $this->createMock(MiddlewareContainer::class);
+        $this->container = new MiddlewareContainer(new ServiceManager([]));
         $this->factory   = new MiddlewareFactory($this->container);
     }
 

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -30,12 +30,11 @@ use function iterator_to_array;
 /** @psalm-import-type MiddlewareParam from MiddlewareFactoryInterface */
 final class MiddlewareFactoryTest extends TestCase
 {
-    /** @var MiddlewareContainer&MockObject */
-    private $container;
+    private MiddlewareContainer&MockObject $container;
 
     private MiddlewareFactory $factory;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->container = $this->createMock(MiddlewareContainer::class);
         $this->factory   = new MiddlewareFactory($this->container);
@@ -182,7 +181,7 @@ final class MiddlewareFactoryTest extends TestCase
     public function testPipelineAllowsAnyTypeSupportedByPrepare(
         $middleware,
         string $assertion,
-        mixed $expected
+        mixed $expected,
     ): void {
         $pipeline = $this->factory->pipeline($middleware);
         $this->assertInstanceOf(MiddlewarePipe::class, $pipeline);
@@ -223,5 +222,12 @@ final class MiddlewareFactoryTest extends TestCase
         $middleware = $this->factory->handler($handler);
 
         self::assertEquals(new RequestHandlerMiddleware($handler), $middleware);
+    }
+
+    public function testAnEmptyArrayOfMiddlewareWillProduceAnEmptyPipeline(): void
+    {
+        $pipeline = $this->factory->prepare([]);
+        self::assertInstanceOf(MiddlewarePipe::class, $pipeline);
+        self::assertSame([], iterator_to_array($pipeline, false));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

The `pipeline()` method suffers from an `Undefined index` notice when given an empty array of middleware as its only argument