### PR TITLE
Unregister whoops in each test case to silence PHPUnit warnings.

### DIFF
--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -59,6 +59,7 @@ final class WhoopsFactoryTest extends TestCase
         $result  = $factory($this->container);
         $this->assertInstanceOf(Whoops::class, $result);
         $this->assertWhoopsContainsHandler(PrettyPageHandler::class, $result);
+        $result->unregister();
     }
 
     public function testWillInjectJsonResponseHandlerIfConfigurationExpectsIt(): void
@@ -71,6 +72,7 @@ final class WhoopsFactoryTest extends TestCase
         $this->assertInstanceOf(Whoops::class, $result);
         $this->assertWhoopsContainsHandler(PrettyPageHandler::class, $result);
         $this->assertWhoopsContainsHandler(JsonResponseHandler::class, $result);
+        $result->unregister();
     }
 
     /**
@@ -111,6 +113,7 @@ final class WhoopsFactoryTest extends TestCase
             && method_exists(WhoopsUtil::class, 'isAjaxRequest')
         ) {
             self::assertInstanceOf(PrettyPageHandler::class, $handler);
+            $whoops->unregister();
 
             // Skip remaining assertions
             return;
@@ -122,6 +125,8 @@ final class WhoopsFactoryTest extends TestCase
         if (method_exists($handler, 'onlyForAjaxRequests')) {
             self::assertSame($isAjaxOnly, $handler->onlyForAjaxRequests());
         }
+
+        $whoops->unregister();
     }
 
     /**
@@ -147,7 +152,8 @@ final class WhoopsFactoryTest extends TestCase
         $this->container->set('config', $config);
 
         $factory = new WhoopsFactory();
-        $factory($this->container);
+        $whoops  = $factory($this->container);
+        $whoops->unregister();
         $this->expectNotToPerformAssertions();
     }
 }


### PR DESCRIPTION
Because Whoops registers error handlers, this causes PHPUnit notices/warnings during testing
