### PR TITLE
Fix code block formatting in error-handling documentation

### DIFF
--- a/docs/book/v3/features/error-handling.md
+++ b/docs/book/v3/features/error-handling.md
@@ -236,6 +236,7 @@ public function getDependencies(): array
         ],
     ];
 }
+```
 
 ## Handling more specific error types
 


### PR DESCRIPTION
<img width="1626" height="1592" alt="Bildschirmfoto 2026-06-10 um 09 40 17@2x" src="https://github.com/user-attachments/assets/548ff9a7-d9f7-498f-b81d-e454ac05419f" />

https://docs.mezzio.dev/mezzio/v3/features/error-handling/#listening-for-errors